### PR TITLE
Feature/Multicall for withdraw vaults

### DIFF
--- a/contexts/useWeb3.js
+++ b/contexts/useWeb3.js
@@ -31,7 +31,7 @@ function getProvider(chain = 'ethereum') {
 		return new ethers.providers.JsonRpcProvider('https://rpcapi.fantom.network');
 	} else if (chain === 'bsc') {
 		return new ethers.providers.JsonRpcProvider('https://bsc-dataseed.binance.org');
-	} else if (chain === 'major') {
+	} else if (chain === 'facuNet') {
 		return new ethers.providers.JsonRpcProvider('http://localhost:8545');
 	}
 	return (new ethers.providers.AlchemyProvider('homestead', process.env.ALCHEMY_KEY));

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "autoprefixer": "^10.3.2",
     "axios": "^0.21.1",
     "dotenv-webpack": "^7.0.3",
+    "ethcall": "4.0.0",
     "ethers": "^5.4.5",
     "grapheme-splitter": "^1.0.4",
     "next": "11.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -267,6 +267,21 @@
     "@ethersproject/properties" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
+"@ethersproject/abi@^5.0.0":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.4.1.tgz#6ac28fafc9ef6f5a7a37e30356a2eb31fa05d39b"
+  integrity sha512-9mhbjUk76BiSluiiW4BaYyI58KSbDMMQpCLdsAR+RsT2GyATiNYxVv+pGWRrekmsIdY3I+hOqsYQSTkc8L/mcg==
+  dependencies:
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/keccak256" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+
 "@ethersproject/abstract-provider@5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz#e404309a29f771bd4d28dbafadcaa184668c2a6e"
@@ -364,7 +379,7 @@
   dependencies:
     "@ethersproject/bignumber" "^5.4.0"
 
-"@ethersproject/contracts@5.4.1":
+"@ethersproject/contracts@5.4.1", "@ethersproject/contracts@^5.0.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.4.1.tgz#3eb4f35b7fe60a962a75804ada2746494df3e470"
   integrity sha512-m+z2ZgPy4pyR15Je//dUaymRUZq5MtDajF6GwFbGAVmKz/RF+DNIPwF0k5qEcL3wPGVqUjFg2/krlCRVTU4T5w==
@@ -477,6 +492,31 @@
   version "5.4.4"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.4.4.tgz#6729120317942fc0ab0ecdb35e944ec6bbedb795"
   integrity sha512-mQevyXj2X2D3l8p/JGDYFZbODhZjW6On15DnCK4Xc9y6b+P0vqorQC/j46omWSm4cyo7BQ/rgfhXNYmvAfyZoQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.4.0"
+    "@ethersproject/abstract-signer" "^5.4.0"
+    "@ethersproject/address" "^5.4.0"
+    "@ethersproject/basex" "^5.4.0"
+    "@ethersproject/bignumber" "^5.4.0"
+    "@ethersproject/bytes" "^5.4.0"
+    "@ethersproject/constants" "^5.4.0"
+    "@ethersproject/hash" "^5.4.0"
+    "@ethersproject/logger" "^5.4.0"
+    "@ethersproject/networks" "^5.4.0"
+    "@ethersproject/properties" "^5.4.0"
+    "@ethersproject/random" "^5.4.0"
+    "@ethersproject/rlp" "^5.4.0"
+    "@ethersproject/sha2" "^5.4.0"
+    "@ethersproject/strings" "^5.4.0"
+    "@ethersproject/transactions" "^5.4.0"
+    "@ethersproject/web" "^5.4.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
+"@ethersproject/providers@^5.0.0":
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.4.5.tgz#eb2ea2a743a8115f79604a8157233a3a2c832928"
+  integrity sha512-1GkrvkiAw3Fj28cwi1Sqm8ED1RtERtpdXmRfwIBGmqBSN5MoeRUHuwHPppMtbPayPgpFcvD7/Gdc9doO5fGYgw==
   dependencies:
     "@ethersproject/abstract-provider" "^5.4.0"
     "@ethersproject/abstract-signer" "^5.4.0"
@@ -795,6 +835,11 @@
   version "12.20.20"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.20.tgz#ce3d6c13c15c5e622a85efcd3a1cb2d9c7fa43a6"
   integrity sha512-kqmxiJg4AT7rsSPIhO6eoBIx9mNwwpeH42yjtgQh6X2ANSpLpvToMXv+LMFdfxpwG1FZXZ41OGZMiUAtbBLEvg==
+
+"@types/node@^14.11.5":
+  version "14.17.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.12.tgz#7a31f720b85a617e54e42d24c4ace136601656c7"
+  integrity sha512-vhUqgjJR1qxwTWV5Ps5txuy2XMdf7Fw+OrdChRboy8BmWUPkckOhphaohzFG6b8DW7CrxaBMdrdJ47SYFq1okw==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -2882,6 +2927,17 @@ eth-sig-util@^1.4.2:
   dependencies:
     ethereumjs-abi "git+https://github.com/ethereumjs/ethereumjs-abi.git"
     ethereumjs-util "^5.1.1"
+
+ethcall@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ethcall/-/ethcall-4.0.0.tgz#755aeba32179ad651ca9c59e06edd289a48bb700"
+  integrity sha512-S2fSDb8+WzdhxZYoCxuqJAc/LIapaHj1v+FQ54ATmCwAaErJMhj75xhpn6ZPykrltT8cDOHKl++5vtcDMILB8Q==
+  dependencies:
+    "@ethersproject/abi" "^5.0.0"
+    "@ethersproject/contracts" "^5.0.0"
+    "@ethersproject/providers" "^5.0.0"
+    "@types/node" "^14.11.5"
+    js-sha3 "^0.8.0"
 
 ethereum-bloom-filters@^1.0.6:
   version "1.0.10"


### PR DESCRIPTION
## What it does ✨
- Replaced the `Promise.all` part of the code by a single multicall to perform 1 single call to detect all the withdraw vaults the user has funds in (from 28 calls).
- Update the name of the mainnetFork

## How to test ✅
Have some funds in a withdraw vault, and check the page. You should see the red alert.
You can also change the address in `page/index.js` to `0x29d9977cfee1423a24181e70e71abc42377dc87a` to test it.

## Note 📝
The multicalls will probably be extended to the vault page to get data a bit faster