### PR TITLE
Feature/Introducing Arbitrum Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To add a new vault to the list, you need to run the following command : `node sc
 This will prompt you with several information:  
 - What's the name of your vault ? (*ex: Hardrock Farmer*)
 - What's the logo for your vault ? (*ex: 🎸👨‍🌾*)
-- Which chain ? (*oneOf: Mainnet (1), BSC (56), Polygon (137), Fantom Opera (250)*)
+- Which chain ? (*oneOf: Mainnet (1), BSC (56), Polygon (137), Fantom Opera (250), Arbitrum One (42161)*)
 - What's the address of your vault ? (*ex: 0x33bd0f9618cf38fea8f7f01e1514ab63b9bde64b*)
 - Who is the dev of this vault ? (*ex: emilianobonassi*)
 
@@ -70,6 +70,7 @@ The following options are available:
 	- `?network=56` for BSC
 	- `?network=137` for Polygon
 	- `?network=250` for Fantom Opera
+	- `?network=42161` for Arbitrum One
 - *rpc*
 	- `?rpc=YOU_CUSTOM_RPC` to use a specific RPC for this request
 

--- a/contexts/useWeb3.js
+++ b/contexts/useWeb3.js
@@ -36,7 +36,10 @@ function getProvider(chain = 'ethereum') {
 		return new ethers.providers.JsonRpcProvider('https://bsc-dataseed.binance.org');
 	} else if (chain === 'major') {
 		return new ethers.providers.JsonRpcProvider('http://localhost:8545');
+	} else if (chain === 'arbitrum') {
+		return new ethers.providers.JsonRpcProvider(`https://speedy-nodes-nyc.moralis.io/${process.env.MORALIS_ARBITRUM_KEY}/arbitrum/mainnet`);
 	}
+
 	return (new ethers.providers.AlchemyProvider('homestead', process.env.ALCHEMY_KEY));
 }
 
@@ -121,7 +124,8 @@ export const Web3ContextApp = ({children}) => {
 					56, // BSC MAINNET
 					137, // MATIC MAINNET
 					250, // FANTOM MAINNET
-					1337, // MAJORNET
+					1337, // MAJORNET,
+					42161, // ARBITRUM MAINNET
 				]
 			});
 			activate(injected, undefined, true);
@@ -137,6 +141,7 @@ export const Web3ContextApp = ({children}) => {
 					137: 'https://rpc-mainnet.matic.network',
 					250: 'https://rpc.ftm.tools',
 					1337: 'http://localhost:8545',
+					42161: `https://speedy-nodes-nyc.moralis.io/${process.env.MORALIS_ARBITRUM_KEY}/arbitrum/mainnet`,
 				},
 				chainId: 1,
 				bridge: 'https://bridge.walletconnect.org',

--- a/next.config.js
+++ b/next.config.js
@@ -20,6 +20,7 @@ module.exports = ({
 		ETHERSCAN_API: process.env.ETHERSCAN_API,
 		POLYGONSCAN_API: process.env.POLYGONSCAN_API,
 		BSCSCAN_API: process.env.BSCSCAN_API,
+		MORALIS_ARBITRUM_KEY: process.env.MORALIS_ARBITRUM_KEY
 	},
 	optimization: {
 		minimize: true,

--- a/pages/api/tvl.js
+++ b/pages/api/tvl.js
@@ -64,7 +64,13 @@ export default fn(async ({network = 1, rpc}) => {
 	if (rpc !== undefined) {
 		provider = new ethers.providers.JsonRpcProvider(rpc);
 	}
-	const	ethcallProvider = await newEthCallProvider(provider);
+	let		ethcallProvider = await newEthCallProvider(provider);
+	if (network === 1337) {
+		ethcallProvider = await newEthCallProvider(new ethers.providers.JsonRpcProvider('http://localhost:8545'));
+		ethcallProvider.multicallAddress = '0xc04d660976c923ddba750341fe5923e47900cf24';
+	} else if (network === 42161) {
+		ethcallProvider.multicallAddress = '0x10126Ceb60954BC35049f24e819A380c505f8a0F';
+	}
 	const	_calls = [];
 	const	_cgIDS = [];
 	let		_tvl = 0;

--- a/pages/api/vaults.js
+++ b/pages/api/vaults.js
@@ -50,7 +50,14 @@ export default fn(async ({network = 1, rpc}) => {
 	if (rpc !== undefined) {
 		provider = new ethers.providers.JsonRpcProvider(rpc);
 	}
-	const	ethcallProvider = await newEthCallProvider(provider);
+	let		ethcallProvider = await newEthCallProvider(provider);
+	if (network === 1337) {
+		ethcallProvider = await newEthCallProvider(new ethers.providers.JsonRpcProvider('http://localhost:8545'));
+		ethcallProvider.multicallAddress = '0xc04d660976c923ddba750341fe5923e47900cf24';
+	} else if (network === 42161) {
+		ethcallProvider.multicallAddress = '0x10126Ceb60954BC35049f24e819A380c505f8a0F';
+	}
+
 	const	_vaults = [];
 	const	_calls = [];
 

--- a/scripts/newVault.js
+++ b/scripts/newVault.js
@@ -57,6 +57,7 @@ const	ENUM_CHAIN = {
 	'BSC (56)': 56,
 	'Polygon (137)': 137,
 	'Fantom Opera (250)': 250,
+	'Arbitrum One (42161)': 42161,
 };
 const	ADDRESS_ZERO = '0x0000000000000000000000000000000000000000';
 const	toAddress = (address) => {
@@ -73,7 +74,6 @@ const	toAddress = (address) => {
 	}
 };
 
-let	defaultVaultABI = 'yVaultV2';
 let	defaultVaultType = 'experimental';
 let	defaultVaultStatus = 'new';
 let	defaultVaultChain = 1;
@@ -112,7 +112,7 @@ if (!args.chain || !([1, 56, 137, 250]).includes(args.chain)) {
 		type: 'list',
 		name: 'vaultChain',
 		message: 'Which chain ?',
-		choices: ['Mainnet (1)', 'BSC (56)', 'Polygon (137)', 'Fantom Opera (250)'],
+		choices: ['Mainnet (1)', 'BSC (56)', 'Polygon (137)', 'Fantom Opera (250)', 'Arbitrum One (42161)'],
 	},);
 } else {
 	if (args.chain === 1)
@@ -123,6 +123,8 @@ if (!args.chain || !([1, 56, 137, 250]).includes(args.chain)) {
 		defaultVaultChain = 'Polygon (137)';
 	if (args.chain === 250)
 		defaultVaultChain = 'Fantom Opera (250)';
+	if (args.chain === 42161)
+		defaultVaultChain = 'Arbitrum One (42161)';
 }
 
 /******************************************************************************

--- a/utils/API.js
+++ b/utils/API.js
@@ -63,6 +63,14 @@ export async function	fetchBlockTimestamp(timestamp, network = 1) {
 		}
 		return null;
 	}
+	if (network === 42161) {
+		const	result = await performGet(`https://api.arbiscan.io/api?module=block&action=getblocknobytime&timestamp=${timestamp}&closest=before&apikey=${process.env.ETHERSCAN_API}`);
+
+		if (result) {
+			return result.result;
+		}
+		return null;
+	}
 
 	const	result = await performGet(`https://api.etherscan.io/api?module=block&action=getblocknobytime&timestamp=${timestamp}&closest=before&apikey=${process.env.ETHERSCAN_API}`);
 

--- a/utils/chains.json
+++ b/utils/chains.json
@@ -59,5 +59,23 @@
         "decimals": 18
       }
     }
+  },
+  "42161": {
+    "chainID": "42161",
+    "name": "Arbitrum One",
+    "displayName": "Arbitrum",
+    "coin": "AETH",
+    "block_explorer": "https://arbiscan.io",
+    "chain_swap": {
+      "chainId": "0xA4B1",
+      "blockExplorerUrls": ["https://arbiscan.io"],
+      "chainName": "Arbitrum One",
+      "rpcUrls": ["https://arb1.arbitrum.io/rpc"],
+      "nativeCurrency": {
+        "name": "AETH",
+        "symbol": "AETH",
+        "decimals": 18
+      }
+    }
   }
 }

--- a/utils/vaults.json
+++ b/utils/vaults.json
@@ -863,5 +863,17 @@
     "COINGECKO_SYMBOL": "dai",
     "VAULT_STATUS": "new",
     "CHAIN_ID": 250
+  },
+  "arbi-one": {
+    "TITLE": "Arbi One",
+    "LOGO": "🥇🥇",
+    "VAULT_ABI": "yVaultV2",
+    "VAULT_TYPE": "experimental",
+    "VAULT_ADDR": "0x237f7928364f291fc52b57945f487d726eff5660",
+    "WANT_ADDR": "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8",
+    "WANT_SYMBOL": "USDC",
+    "COINGECKO_SYMBOL": "usd-coin",
+    "VAULT_STATUS": "new",
+    "CHAIN_ID": 42161
   }
 }


### PR DESCRIPTION
## What it does ✨
First iteration to add the Arbitrum vaults to ape.tax.
A custom RPC is used to get a node archive to get some data, via [Moralis](https://docs.moralis.io/speedy-nodes/connecting-to-rpc-nodes/connect-to-arbitrum-node).
An update is made on the multicall contract based on [this PR](https://github.com/Destiner/ethcall/pull/11)
The stats are not enabled for now because of an issue with the RPC.

## How to test ✅
The first and only vault should be visible and visitable.