### PR TITLE
[Feature] yearn.meta only when possible

### DIFF
--- a/pages/[slug]/index.js
+++ b/pages/[slug]/index.js
@@ -17,7 +17,7 @@ import	useWindowInFocus														from	'hook/useWindowInFocus';
 import	vaults																	from	'utils/vaults.json';
 import	chains																	from	'utils/chains.json';
 import	{performGet}															from	'utils/API';
-import	{ADDRESS_ZERO, asyncForEach, bigNumber, formatAmount}					from	'utils';
+import	{ADDRESS_ZERO, bigNumber, formatAmount}									from	'utils';
 import	{approveToken, depositToken, withdrawToken, apeInVault, apeOutVault}	from	'utils/actions';
 import	ERC20ABI																from	'utils/ABI/erc20.abi.json';
 import	YVAULTABI																from	'utils/ABI/yVault.abi.json';
@@ -118,11 +118,10 @@ function	Strategies({vault, chainID}) {
 		}
 
 		const	vaultContract = new ethers.Contract(vault.VAULT_ADDR, ['function withdrawalQueue(uint256 arg0) view returns (address)'], provider);
-		const	strategiesIndex = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19];
 		let		shouldBreak = false;
-		asyncForEach(strategiesIndex, async (index) => {
+		for (let index = 0; index < 20; index++) {
 			if (shouldBreak) {
-				return;
+				continue;
 			}
 
 			/**************************************************************************
@@ -133,18 +132,26 @@ function	Strategies({vault, chainID}) {
 			const	strategyAddress = await vaultContract.withdrawalQueue(index);
 			if (strategyAddress === ADDRESS_ZERO) {
 				shouldBreak = true;
-				return;
+				continue;
 			}
 			const	strategyContract = new ethers.Contract(strategyAddress, ['function name() view returns (string)'], provider);
 			const	name = await strategyContract.name();
-			const	details = await performGet(`https://meta.yearn.network/strategies/${vault.CHAIN_ID}/${strategyAddress}`);
+			if ([1, 250, 42161].includes(Number(vault.CHAIN_ID))) {
+				const	details = await performGet(`https://meta.yearn.network/strategies/${vault.CHAIN_ID}/${strategyAddress}`);
+				set_strategiesData((s) => {
+					s[index] = {address: strategyAddress, name, description: details?.description ? parseMarkdown(details?.description.replaceAll('{{token}}', vault.WANT_SYMBOL)) : null};
+					return (s);
+				});
+			} else {
+				set_strategiesData((s) => {
+					s[index] = {address: strategyAddress, name, description: 'Description not provided for this strategy.'};
+					return (s);
+				});
+			}
 			
-			set_strategiesData((s) => {
-				s[index] = {address: strategyAddress, name, description: details?.description ? parseMarkdown(details?.description.replaceAll('{{token}}', vault.WANT_SYMBOL)) : null};
-				return (s);
-			});
 			set_nonce(n => n + 1);
-		});
+		}
+
 	}, [chainID, vault.CHAIN_ID, vault.VAULT_ADDR, provider]);
 
 	useEffect(() => {

--- a/utils/vaults.json
+++ b/utils/vaults.json
@@ -1043,5 +1043,17 @@
     "COINGECKO_SYMBOL": "weth",
     "VAULT_STATUS": "new",
     "CHAIN_ID": 100
+  },
+  "curved-owl": {
+    "TITLE": "Curved Owl",
+    "LOGO": "🦉🥌",
+    "VAULT_ABI": "yVaultV2",
+    "VAULT_TYPE": "experimental",
+    "VAULT_ADDR": "0xFfe9fa48A805AC26eEF9DC750765C4dFB530f70b",
+    "WANT_ADDR": "0x1337bedc9d22ecbe766df105c9623922a27963ec",
+    "WANT_SYMBOL": "x3CRV",
+    "COINGECKO_SYMBOL": "wrapped-xdai",
+    "VAULT_STATUS": "new",
+    "CHAIN_ID": 100
   }
 }

--- a/utils/vaults.json
+++ b/utils/vaults.json
@@ -1020,30 +1020,6 @@
     "VAULT_STATUS": "new",
     "CHAIN_ID": 1
   },
-  "ywxdai": {
-    "TITLE": "Basic Wrapped xDai Farmer",
-    "LOGO": "🏆🚀",
-    "VAULT_ABI": "yVaultV2",
-    "VAULT_TYPE": "experimental",
-    "VAULT_ADDR": "0xE35f0516D330395a3878eB60114349b6325ec02E",
-    "WANT_ADDR": "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d",
-    "WANT_SYMBOL": "wxDai",
-    "COINGECKO_SYMBOL": "wrapped-xdai",
-    "VAULT_STATUS": "new",
-    "CHAIN_ID": 100
-  },
-  "ygnoweth": {
-    "TITLE": "yGnoWETH",
-    "LOGO": "🦉🌯",
-    "VAULT_ABI": "yVaultV2",
-    "VAULT_TYPE": "experimental",
-    "VAULT_ADDR": "0x7d86C052b20bA21b2E29a7D6cc1D2915F138c53a",
-    "WANT_ADDR": "0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1",
-    "WANT_SYMBOL": "WETH",
-    "COINGECKO_SYMBOL": "weth",
-    "VAULT_STATUS": "new",
-    "CHAIN_ID": 100
-  },
   "curved-owl": {
     "TITLE": "Curved Owl",
     "LOGO": "🦉🥌",


### PR DESCRIPTION
Disable the call to meta.yearn when the chain is not supported, and add a `Strategy with no description` message in this situation.