### PR TITLE
style: adjust text styles to improve readability

### DIFF
--- a/components/VaultDetails.tsx
+++ b/components/VaultDetails.tsx
@@ -26,7 +26,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 				<div>
 					<p className={'inline text-neutral-900'}>{'Vault: '}</p>
 					<a
-						className={'dashed-underline-gray text-neutral-700'}
+						className={'dashed-underline-gray ml-3 text-neutral-700'}
 						href={`${chainExplorer}/address/${vault.VAULT_ADDR}#code`}
 						target={'_blank'}
 						rel={'noreferrer'}>
@@ -35,13 +35,13 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 				</div>
 				<div>
 					<p className={'inline text-neutral-900'}>{'Version: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'ml-3 inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>{vaultData.apiVersion}</Suspense>
 					</p>
 				</div>
 				<div>
 					<p className={'inline text-neutral-900'}>{`${vault.WANT_SYMBOL} price (${vault?.PRICE_SOURCE ? vault.PRICE_SOURCE : 'CoinGecko 🦎'}): `}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'ml-3 inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`$${vaultData.wantPrice ? formatAmount(vaultData.wantPrice, vaultData.wantPrice < 10 ? 4 : 2) : '-'}`}
 						</Suspense>
@@ -49,7 +49,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 				</div>
 				<div>
 					<p className={'inline text-neutral-900'}>{'Deposit Limit: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'ml-3 inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${vaultData.depositLimit.raw.isZero() ? '-' : formatAmount(vaultData?.depositLimit.normalized, 2)} ${vault.WANT_SYMBOL}`}
 						</Suspense>
@@ -57,7 +57,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 				</div>
 				<div>
 					<p className={'inline text-neutral-900'}>{'Total Assets: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'ml-3 inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${formatAmount(vaultData?.totalAssets.normalized, 2)} ${vault.WANT_SYMBOL}`}
 						</Suspense>
@@ -65,7 +65,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 				</div>
 				<div>
 					<p className={'inline text-neutral-900'}>{'Total AUM: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'ml-3 inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`$${vaultData.totalAUM === 0 ? '-' : formatAmount(vaultData.totalAUM, 2)}`}
 						</Suspense>
@@ -75,7 +75,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 			<div className={`mb-4 font-mono text-sm font-medium ${vault.VAULT_STATUS === 'withdraw' || vault.CHAIN_ID === 56 ? 'hidden' : ''}`}>
 				<div>
 					<p className={'inline text-neutral-900'}>{'Gross APR (last week): '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'ml-3 inline text-neutral-700'}>
 						<Suspense wait={!!vaultAPY && !isLoading}>
 							{`${vaultAPY?.week || '-'}`}
 						</Suspense>
@@ -83,7 +83,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 				</div>
 				<div>
 					<p className={'inline text-neutral-900'}>{'Gross APR (last month): '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'ml-3 inline text-neutral-700'}>
 						<Suspense wait={!!vaultAPY && !isLoading}>
 							{`${vaultAPY?.month || '-'}`}
 						</Suspense>
@@ -91,7 +91,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 				</div>
 				<div>
 					<p className={'inline text-neutral-900'}>{'Gross APR (inception): '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'ml-3 inline text-neutral-700'}>
 						<Suspense wait={!!vaultAPY && !isLoading}>
 							{`${vaultAPY?.inception || '-'}`}
 						</Suspense>
@@ -101,7 +101,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 			<div className={'mb-4 font-mono text-sm font-medium text-neutral-700'}>
 				<div>
 					<p className={'inline text-neutral-900'}>{'Price Per Share: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'ml-3 inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${vaultData.pricePerShare.normalized}`}
 						</Suspense>
@@ -109,7 +109,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 				</div>
 				<div>
 					<p className={'inline text-neutral-900'}>{'Available limit: '}</p>
-					<p className={'inline text-neutral-700'}>
+					<p className={'ml-3 inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
 							{`${formatAmount(vaultData.availableDepositLimit.normalized, 2)} ${vault.WANT_SYMBOL}`}
 						</Suspense>

--- a/components/VaultWallet.tsx
+++ b/components/VaultWallet.tsx
@@ -17,23 +17,23 @@ function	VaultWallet({vault, vaultData}: {vault: TVault, vaultData: TVaultData})
 			<div className={'mb-4 font-mono text-sm font-medium text-neutral-700'}>
 				<div>
 					<p className={'inline text-neutral-700'}>{'Your Account: '}</p>
-					<p className={'inline text-neutral-700'}>{ens || `${truncateHex(toAddress(address), 5)}`}</p>
+					<p className={'ml-3 inline text-neutral-700'}>{ens || `${truncateHex(toAddress(address), 5)}`}</p>
 				</div>
 				<div>
 					<p className={'inline text-neutral-700'}>{'Your vault shares: '}</p>
-					<p className={'inline text-neutral-700'}>{`${formatAmount(vaultData?.balanceOf.normalized, 2)}`}</p>
+					<p className={'ml-3 inline text-neutral-700'}>{`${formatAmount(vaultData?.balanceOf.normalized, 2)}`}</p>
 				</div>
 				<div>
 					<p className={'inline text-neutral-700'}>{'Your shares value: '}</p>
-					<p className={'inline text-neutral-700'}>{`${vaultData.balanceOfValue === 0 ? '-' : formatAmount(vaultData?.balanceOfValue, 2)}`}</p>
+					<p className={'ml-3 inline text-neutral-700'}>{`${vaultData.balanceOfValue === 0 ? '-' : formatAmount(vaultData?.balanceOfValue, 2)}`}</p>
 				</div>
 				<div>
 					<p className={'inline text-neutral-700'}>{`Your ${vault.WANT_SYMBOL} Balance: `}</p>
-					<p className={'inline text-neutral-700'}>{`${formatAmount(vaultData?.wantBalance.normalized, 2)}`}</p>
+					<p className={'ml-3 inline text-neutral-700'}>{`${formatAmount(vaultData?.wantBalance.normalized, 2)}`}</p>
 				</div>
 				<div>
 					<p className={'inline text-neutral-700'}>{`Your ${chainCoin} Balance: `}</p>
-					<p className={'inline text-neutral-700'}>{`${formatAmount(vaultData?.coinBalance.normalized, 2)}`}</p>
+					<p className={'ml-3 inline text-neutral-700'}>{`${formatAmount(vaultData?.coinBalance.normalized, 2)}`}</p>
 				</div>
 			</div>
 		</section>

--- a/pages/newVault.tsx
+++ b/pages/newVault.tsx
@@ -207,24 +207,24 @@ function	Index(): ReactElement {
 
 					<div>
 						<div className={'mb-6 mt-12 flex flex-col space-y-2'}>
-							<label className={'-mb-1 text-xs font-semibold text-neutral-700'}>{'Gauge Address'}</label>
+							<label className={'-mb-1 text-xs font-semibold text-neutral-700'}>{'Gauge Address:'}</label>
 							<ComboBox selectedGauge={selectedGauge} set_selectedGauge={set_selectedGauge} />
 						</div>
 						<div className={'mb-12 flex flex-col space-y-3'}>
 							<div>
-								<label className={'text-xs font-semibold text-neutral-700'}>{'Vault Name'}</label>
+								<label className={'text-xs font-semibold text-neutral-700'}>{'Vault Name:'}</label>
 								<p className={'font-mono text-neutral-700'}>
 									{gaugeInfo.exists ? `Balancer ${gaugeInfo.symbol} Auto-Compounding yVault` : '-'}
 								</p>
 							</div>
 							<div>
-								<label className={'text-xs font-semibold text-neutral-700'}>{'Vault Symbol'}</label>
+								<label className={'text-xs font-semibold text-neutral-700'}>{'Vault Symbol:'}</label>
 								<p className={'font-mono text-neutral-700'}>
 									{gaugeInfo.exists ? `yvBlp${gaugeInfo.symbol}` : '-'}
 								</p>
 							</div>
 							<div>
-								<label className={'text-xs font-semibold text-neutral-700'}>{'Vault Address'}</label>
+								<label className={'text-xs font-semibold text-neutral-700'}>{'Vault Address:'}</label>
 								{gaugeInfo.deployed ? <AddressWithActions
 									explorer={'https://etherscan.io'}
 									className={'font-mono font-normal text-neutral-700'}


### PR DESCRIPTION
## Description

This PR makes minor adjustments to more clearly show difference between labels and dynamic values. It builds on a previous PR that attempted to standardize text using only a few simple rules (see: https://github.com/0xMirim/ape-tax/pull/1). 

Since we had our simple rules in place here the goal was to address additional feedback while not breaking the standardized rules we already set. 

Primary concerns:
1. Difficult to differentiate between labels and dynamic vaults within vaults (wallet and top sections): 
   * The initial text standardization attempt made us change color of labels and data to `text-neutral-700`. Instead of expand to more colors again I thought it would be better to show the difference with some space (margin) between the label and data. This was applied to both the Wallet section as well as the top section within each vault. 

2. More differentiation between label and value requested on `deploy your own vault` page
   * I didn't really feel like color or space would really improve things here. I added a colon `:` to the end of each label since I feel this is pretty standard to let the user know that what comes after is a dynamic data value.
  
3. Vault list should be darker
   * Handled in previous text style PR 

Spacing changes visual (before / after):

<img width="400" alt="before" src="https://github.com/saltyfacu/ape-tax/assets/95051992/365f37dc-8a93-4855-8bbd-ab6d114c969a">
<img width="400" alt="after" src="https://github.com/saltyfacu/ape-tax/assets/95051992/ef355630-8d3e-41a5-b8a7-1957605e0763">




## Motivation and Context

Address feedback related to text styles received from team members.

## How Has This Been Tested?

Manually 
