### PR TITLE
Resolve nested links console error

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -259,9 +259,9 @@ function	Index(): ReactElement {
 					<h2 className={'mb-4 font-mono text-2xl font-semibold text-neutral-900'}>{'🚀 Experimental'}</h2>
 					<ul>
 						{vaultsActiveExperimental?.map((vault): ReactElement => (
-							<li key={vault.VAULT_SLUG} className={'cursor-pointer'}>
+							<li key={vault.VAULT_SLUG} className={'flex cursor-pointer flex-row items-baseline'}>
 								<Link href={`/${vault.VAULT_SLUG}`}>
-									<div className={'my-4 flex flex-row items-center'}>
+									<div className={'mb-4 flex flex-row items-center'}>
 										<span className={'flex flex-row items-center'}>
 											{
 												(vault.LOGO_ARR || []).map((letter, index): ReactElement => (
@@ -272,9 +272,9 @@ function	Index(): ReactElement {
 										<span className={'dashed-underline-gray ml-4 cursor-pointer font-mono text-base font-normal text-neutral-700'}>
 											{vault.TITLE}
 										</span>
-										<Tag status={vault.VAULT_STATUS} />
 									</div>
 								</Link>
+								<Tag status={vault.VAULT_STATUS} />
 							</li>
 						))}
 					</ul>
@@ -284,9 +284,9 @@ function	Index(): ReactElement {
 					<h2 className={'mb-4 font-mono text-2xl font-semibold text-neutral-900'}>{'🧠 Weird'}</h2>
 					<ul>
 						{vaultsActiveWeird?.map((vault): ReactElement => (
-							<li key={vault.VAULT_SLUG} className={'cursor-pointer'}>
+							<li key={vault.VAULT_SLUG} className={'flex cursor-pointer flex-row items-baseline'}>
 								<Link href={`/${vault.VAULT_SLUG}`}>
-									<div className={'my-4 flex flex-row items-center'}>
+									<div className={'mb-4 flex flex-row items-center'}>
 										<span className={'flex flex-row items-center'}>
 											{
 												(vault.LOGO_ARR || []).map((letter, index): ReactElement => (
@@ -297,9 +297,9 @@ function	Index(): ReactElement {
 										<span className={'dashed-underline-gray ml-4 cursor-pointer font-mono text-base font-normal text-neutral-700'}>
 											{vault.TITLE}
 										</span>
-										<Tag status={vault.VAULT_STATUS} />
 									</div>
 								</Link>
+								<Tag status={vault.VAULT_STATUS} />
 							</li>
 						))}
 					</ul>


### PR DESCRIPTION
This PR resolves a distracting error we get in the console as seen below. The error has to do with `Tag` component in `index.tsx`. The `Tag` component by itself is ok since it's really just a wrapper for <a> tags that to link other sites.

The issues comes in when we use `Tag` within each `Link` because link is also <a> underthehood so we get this nested links error. The solution was just to examine the HTML structure and make minimal adjustments to remove `Tag` from within the `Link` while preserving the original appearance. It was a bit tricky but I think this solution is good.  

<img width="553" alt="error" src="https://github.com/saltyfacu/ape-tax/assets/95051992/aa806cf3-1e44-4400-9e7d-39f3523a8dcc">
