### PR TITLE
refactor: Update react imports

### DIFF
--- a/components/AddressWithAction.js
+++ b/components/AddressWithAction.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useSettings} from '@yearn-finance/web-lib/contexts/useSettings';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import IconCopy from '@yearn-finance/web-lib/icons/IconCopy';

--- a/components/AnimatedWait.js
+++ b/components/AnimatedWait.js
@@ -1,5 +1,5 @@
 
-import	React, {useEffect, useState}	from	'react';
+import	{useEffect, useState}	from	'react';
 
 function	AnimatedWait() {
 	const frames = ['[-----]', '[=----]', '[-=---]', '[--=--]', '[---=-]', '[----=]'];

--- a/components/InfoMessage.js
+++ b/components/InfoMessage.js
@@ -1,4 +1,3 @@
-import	React	from	'react';
 
 function	InfoMessage({status}) {
 	if (status === 'use_production' || status === 'endorsed') {

--- a/components/Meta.js
+++ b/components/Meta.js
@@ -1,4 +1,3 @@
-import	React			from	'react';
 import	Head			from	'next/head';
 import	{DefaultSeo}	from	'next-seo';
 import	meta			from	'public/manifest.json';

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import {useState} from 'react';
 import Link from 'next/link';
 import chains from 'utils/chains.json';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';

--- a/components/Suspense.js
+++ b/components/Suspense.js
@@ -1,4 +1,3 @@
-import	React					from	'react';
 import	AnimatedWait			from	'components/AnimatedWait';
 
 function	Suspense({wait, children}) {

--- a/components/VaultActions.js
+++ b/components/VaultActions.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import {useState} from 'react';
 import {ethers} from 'ethers';
 import {apeInVault, apeOutVault, approveToken, depositToken, withdrawToken} from 'utils/actions';
 import chains from 'utils/chains.json';

--- a/components/VaultDetails.js
+++ b/components/VaultDetails.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import ProgressChart from 'components/ProgressChart';
 import Suspense from 'components/Suspense';
 import {formatAmount} from 'utils';

--- a/components/VaultStrategies.js
+++ b/components/VaultStrategies.js
@@ -1,5 +1,5 @@
 
-import React, {useCallback, useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {Contract} from 'ethcall';
 import {ethers} from 'ethers';
 import {parseMarkdown} from 'utils';

--- a/components/VaultWallet.js
+++ b/components/VaultWallet.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {formatAmount} from 'utils';
 import chains from 'utils/chains.json';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';

--- a/components/VaultWrapper.js
+++ b/components/VaultWrapper.js
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import InfoMessage from 'components/InfoMessage';
 import VaultActions from 'components/VaultActions';
 import VaultDetails from 'components/VaultDetails';

--- a/contexts/useBalancerGauges.js
+++ b/contexts/useBalancerGauges.js
@@ -1,4 +1,4 @@
-import React, {createContext, useContext} from 'react';
+import {createContext, useCallback, useContext, useEffect, useState} from 'react';
 import {Contract} from 'ethcall';
 import {request} from 'graphql-request';
 import AURA_BOOSTER_ABI from 'utils/ABI/auraBooster.abi';
@@ -16,8 +16,8 @@ import {getProvider, newEthCallProvider} from '@yearn-finance/web-lib/utils/web3
 const	BalancerGaugeContext = createContext();
 export const BalancerGaugeContextApp = ({children}) => {
 	const	{provider, chainID} = useWeb3();
-	const	[balancerGauges, set_balancerGauges] = React.useState(undefined);
-	const	[nonce, set_nonce] = React.useState(0);
+	const	[balancerGauges, set_balancerGauges] = useState(undefined);
+	const	[nonce, set_nonce] = useState(0);
 
 	/* 🔵 - Yearn Finance ******************************************************
 	**	getBalanceGauges will perform a graphQL query to the balancer subgraph
@@ -25,7 +25,7 @@ export const BalancerGaugeContextApp = ({children}) => {
 	**	asynchronously and followed by a multicall to get the name and symbols
 	**	of each of theses gauges.
 	***************************************************************************/
-	const getBalanceGauges = React.useCallback(async () => {
+	const getBalanceGauges = useCallback(async () => {
 		if (chainID !== 1 && chainID !== 1337) {
 			performBatchedUpdates(() => {
 				set_balancerGauges(undefined);
@@ -87,7 +87,7 @@ export const BalancerGaugeContextApp = ({children}) => {
 		});
 	}, [provider, chainID]);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		getBalanceGauges();
 	}, [getBalanceGauges]);
 

--- a/contexts/useFactory.js
+++ b/contexts/useFactory.js
@@ -1,4 +1,4 @@
-import React, {createContext, useContext} from 'react';
+import {createContext, useCallback, useContext, useEffect, useState} from 'react';
 import {Contract} from 'ethcall';
 import FACTORY_ABI from 'utils/ABI/factory.abi';
 import YVAULT_ABI from 'utils/ABI/yVault.abi';
@@ -14,13 +14,13 @@ import {getProvider, newEthCallProvider} from '@yearn-finance/web-lib/utils/web3
 const	FactoryContext = createContext();
 export const FactoryContextApp = ({children}) => {
 	const	{provider, chainID} = useWeb3();
-	const	[communityVaults, set_communityVaults] = React.useState(undefined);
-	const	[nonce, set_nonce] = React.useState(0);
+	const	[communityVaults, set_communityVaults] = useState(undefined);
+	const	[nonce, set_nonce] = useState(0);
 
 	/* 🔵 - Yearn Finance ******************************************************
 	**	getCommunityVaults will fetch the currently deployed community vaults
 	***************************************************************************/
-	const getCommunityVaults = React.useCallback(async () => {
+	const getCommunityVaults = useCallback(async () => {
 		if (chainID !== 1 && chainID !== 1337) {
 			performBatchedUpdates(() => {
 				set_communityVaults(undefined);
@@ -77,7 +77,7 @@ export const FactoryContextApp = ({children}) => {
 		});
 	}, [provider, chainID]);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		getCommunityVaults();
 	}, [getCommunityVaults]);
 

--- a/hook/useWindowInFocus.js
+++ b/hook/useWindowInFocus.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import {useEffect, useState} from 'react';
 
 const useWindowInFocus = () => {
-	const [focused, setFocused] = React.useState(true);
-	React.useEffect(() => {
+	const [focused, setFocused] = useState(true);
+	useEffect(() => {
 		const onFocus = () => setFocused(true);
 		const onBlur = () => setFocused(false);
 

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,5 +1,3 @@
-import	React	from	'react';
-
 function	Index() {
 	return (
 		<section aria-label={'404'}>

--- a/pages/[slug]/index.js
+++ b/pages/[slug]/index.js
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react';
+import {useCallback, useState} from 'react';
 import {NextSeo} from 'next-seo';
 import VaultDetails from 'components/VaultWrapper';
 import useFactory from 'contexts/useFactory';
@@ -13,7 +13,7 @@ import {getProvider} from '@yearn-finance/web-lib/utils/web3/providers';
 function Wrapper({vault, slug, prices}) {
 	const	{provider, isActive, address, ens, chainID, openModalLogin} = useWeb3();
 	const	{communityVaults} = useFactory();
-	const	[currentVault, set_currentVault] = React.useState(vault);
+	const	[currentVault, set_currentVault] = useState(vault);
 	const	windowInFocus = useWindowInFocus();
 
 	/* 🔵 - Yearn Finance ******************************************************

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {Toaster} from 'react-hot-toast';
 import Meta from 'components/Meta';
 import Navbar from 'components/Navbar';

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import Document, {Head, Html, Main, NextScript} from 'next/document';
 
 class MyDocument extends Document {

--- a/pages/index.js
+++ b/pages/index.js
@@ -190,7 +190,7 @@ function	Index() {
 					<h1 className={'mb-6 font-mono text-3xl font-semibold leading-9 text-neutral-900'}>{'Experimental Experiments Registry'}</h1>
 				</div>
 				<div className={'flex md:hidden'}>
-					<h1 className={'font-mono text-xl font-semibold leading-9 text-neutral-900'}>{'Ex'}<sup className={'mt-4 mr-2'}>{'2'}</sup>{' Registry'}</h1>
+					<h1 className={'font-mono text-xl font-semibold leading-9 text-neutral-900'}>{'Ex'}<sup className={'mr-2 mt-4'}>{'2'}</sup>{' Registry'}</h1>
 				</div>
 			</div>
 			<div className={'my-4 max-w-5xl bg-yellow-900 p-4 font-mono text-sm font-normal text-[#485570]'}>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import Link from 'next/link';
 import useFactory from 'contexts/useFactory';
 import {ethers} from 'ethers';

--- a/pages/newVault.js
+++ b/pages/newVault.js
@@ -1,4 +1,4 @@
-import React, {Fragment, useState} from 'react';
+import {Fragment, useCallback, useEffect, useState} from 'react';
 import {AddressWithActions} from 'components/AddressWithAction';
 import useBalancerGauge from 'contexts/useBalancerGauges';
 import useFactory from 'contexts/useFactory';
@@ -33,7 +33,7 @@ function ComboBox({selectedGauge, set_selectedGauge}) {
 			<div className={'relative'}>
 				<div className={'w-full'}>
 					<Combobox.Input
-						className={'w-full border-neutral-400 bg-white/0 py-1.5 px-2 font-mono text-neutral-700 focus:border-neutral-700 focus:ring-0 active:ring-0'}
+						className={'w-full border-neutral-400 bg-white/0 px-2 py-1.5 font-mono text-neutral-700 focus:border-neutral-700 focus:ring-0 active:ring-0'}
 						displayValue={(gauge) => gauge?.address}
 						onChange={(event) => setQuery(event.target.value)}
 					/>
@@ -61,7 +61,7 @@ function ComboBox({selectedGauge, set_selectedGauge}) {
 				>
 					<Combobox.Options className={'absolute mt-1 max-h-60 w-full overflow-auto border border-neutral-400 bg-neutral-0 py-1 text-base focus:outline-none'}>
 						{!filteredGauges || (filteredGauges || [])?.length === 0 && query !== '' ? (
-							<div className={'relative cursor-default select-none py-2 px-4 text-neutral-700'}>
+							<div className={'relative cursor-default select-none px-4 py-2 text-neutral-700'}>
 								{'Nothing found.'}
 							</div>
 						) : (
@@ -92,10 +92,10 @@ function ComboBox({selectedGauge, set_selectedGauge}) {
 function	Index() {
 	const	{getCommunityVaults} = useFactory();
 	const	{provider, isActive} = useWeb3();
-	const	[selectedGauge, set_selectedGauge] = React.useState();
-	const	[gaugeInfo, set_gaugeInfo] = React.useState({exists: false, name: '', symbol: '', deployed: false, vaultAddress: ''});
-	const	[error, set_error] = React.useState(undefined);
-	const	[txStatusCreateVault, set_txStatusCreateVault] = React.useState(defaultTxStatus);
+	const	[selectedGauge, set_selectedGauge] = useState();
+	const	[gaugeInfo, set_gaugeInfo] = useState({exists: false, name: '', symbol: '', deployed: false, vaultAddress: ''});
+	const	[error, set_error] = useState(undefined);
+	const	[txStatusCreateVault, set_txStatusCreateVault] = useState(defaultTxStatus);
 	
 	/* 🔵 - Yearn Finance ******************************************************
 	** The checkGauge callback will, for a given gauge address, check if the
@@ -103,7 +103,7 @@ function	Index() {
 	** the gauge. If the gauge has already been deployed as a vault, an error
 	** will be thrown indicating that the vault already exists.
 	**************************************************************************/
-	const	checkGauge = React.useCallback(async () => {
+	const	checkGauge = useCallback(async () => {
 		const	ethcallProvider = await newEthCallProvider(provider);
 		const	balancerGlobalContract = new Contract(process.env.YEARN_BALANCER_FACTORY_ADDRESS, [{'stateMutability':'view', 'type':'function', 'name':'alreadyExistsFromGauge', 'inputs':[{'name':'address', 'type':'address'}], 'outputs':[{'name':'', 'type':'address'}]}]);
 		const	gaugeContract = new Contract(selectedGauge?.address, [{'stateMutability':'view', 'type':'function', 'name':'name', 'inputs':[], 'outputs':[{'name':'', 'type':'string'}]}, {'stateMutability':'view', 'type':'function', 'name':'symbol', 'inputs':[], 'outputs':[{'name':'', 'type':'string'}]}]);
@@ -126,7 +126,7 @@ function	Index() {
 			});
 		}
 	}, [provider, selectedGauge?.address]);
-	React.useEffect(() => {
+	useEffect(() => {
 		if (!isZeroAddress(selectedGauge?.address)) {
 			checkGauge();
 		} else {
@@ -181,7 +181,7 @@ function	Index() {
 					<h1 className={'mb-6 font-mono text-3xl font-semibold leading-9 text-neutral-900'}>{'Experimental Experiments Registry'}</h1>
 				</div>
 				<div className={'flex md:hidden'}>
-					<h1 className={'font-mono text-xl font-semibold leading-9 text-neutral-900'}>{'Ex'}<sup className={'mt-4 mr-2'}>{'2'}</sup>{' Registry'}</h1>
+					<h1 className={'font-mono text-xl font-semibold leading-9 text-neutral-900'}>{'Ex'}<sup className={'mr-2 mt-4'}>{'2'}</sup>{' Registry'}</h1>
 				</div>
 			</div>
 			<div className={'my-4 max-w-5xl bg-yellow-900 p-4 font-mono text-sm font-normal text-[#485570]'}>
@@ -204,7 +204,7 @@ function	Index() {
 					</div>
 
 					<div>
-						<div className={'mt-12 mb-6 flex flex-col space-y-2'}>
+						<div className={'mb-6 mt-12 flex flex-col space-y-2'}>
 							<label className={'-mb-1 text-xs font-semibold text-neutral-900/60'}>{'Gauge Address'}</label>
 							<ComboBox selectedGauge={selectedGauge} set_selectedGauge={set_selectedGauge} />
 						</div>
@@ -234,7 +234,7 @@ function	Index() {
 						<button
 							onClick={onCreateVault}
 							disabled={!selectedGauge || isZeroAddress(selectedGauge.address) || error || txStatusCreateVault.pending}
-							className={`${!selectedGauge || isZeroAddress(selectedGauge.address) || error ? 'bg-neutral-50 cursor-not-allowed opacity-30' : 'bg-neutral-50 hover:bg-neutral-100'} mr-2 mb-2 w-full border border-solid border-neutral-500 p-1.5 font-mono text-sm font-semibold text-neutral-900 transition-colors`}>
+							className={`${!selectedGauge || isZeroAddress(selectedGauge.address) || error ? 'bg-neutral-50 cursor-not-allowed opacity-30' : 'bg-neutral-50 hover:bg-neutral-100'} mb-2 mr-2 w-full border border-solid border-neutral-500 p-1.5 font-mono text-sm font-semibold text-neutral-900 transition-colors`}>
 							{error ? '❌ A vault already exists for this gauge' : '🤯 Create your own Vault'}
 						</button>
 					</div>

--- a/pages/yvsteth.js
+++ b/pages/yvsteth.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {BigNumber, ethers} from 'ethers';
 import {formatAmount} from 'utils';
 import {approveToken, depositToken, withdrawToken} from 'utils/actions';


### PR DESCRIPTION
## Description

This PR has the purpose adjust and remove unnecessary react imports in this repo.

In these cases:

     import React, {useEffect, useState} from 'react';

The first 'React' was removed leaving only the hooks or complements:

    import {useEffect, useState} from 'react';

and lines that only imported React from 'react', they were removed.

Extra: Fixed some warnings "Invalid Tailwind CSS classnames order".

## Related Issue

N/A

## Motivation and Context

The motivation by removing unnecessary imports is to keep the code as clean as possible.  Directly importing react used to be required but for a while now it hasn't been. 

## How Has This Been Tested?

After making the changes I ran 'yarn dev' and confirmed that there was no error or loss of functionality, everything appeared as expected.

## Resources

Reference: [The New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)