### PR TITLE
chore: Improve responsiveness of navbar

### DIFF
--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -70,7 +70,7 @@ function	Navbar({router}) {
 				suppressHydrationWarning
 				className={'inline-flex cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-400 bg-neutral-0 px-3 py-2 font-mono text-xs font-semibold leading-4 text-neutral-700'}>
 				<svg
-					className={'mr-0 lg:mr-2'}
+					className={'mr-0 md:mr-2'}
 					width={'16'}
 					height={'16'}
 					viewBox={'0 0 16 16'}
@@ -78,7 +78,7 @@ function	Navbar({router}) {
 					xmlns={'http://www.w3.org/2000/svg'}>
 					<path d={'M12.6667 0H3.33333C1.46667 0 0 1.46667 0 3.33333V12.6667C0 14.5333 1.46667 16 3.33333 16H12.6667C14.5333 16 16 14.5333 16 12.6667V3.33333C16 1.46667 14.5333 0 12.6667 0ZM4.66667 5C5.2 5 5.66667 5.46667 5.66667 6C5.66667 6.53333 5.2 7 4.66667 7C4.13333 7 3.66667 6.53333 3.66667 6C3.66667 5.46667 4.13333 5 4.66667 5ZM12.0667 10.4C10.9333 11.4667 9.46667 12.0667 8 12.0667C6.53333 12.0667 5 11.4667 3.93333 10.4C3.8 10.2667 3.73333 10.1333 3.73333 9.93333C3.73333 9.53333 4 9.26667 4.4 9.26667C4.6 9.26667 4.73333 9.33333 4.86667 9.46667C5.73333 10.3333 6.86667 10.8 8 10.8C9.13333 10.8 10.2667 10.3333 11.1333 9.46667C11.2667 9.33333 11.4 9.26667 11.6 9.26667C12 9.26667 12.2667 9.53333 12.2667 9.93333C12.2667 10.1333 12.2 10.2667 12.0667 10.4ZM11.3333 7C10.8 7 10.3333 6.53333 10.3333 6C10.3333 5.46667 10.8 5 11.3333 5C11.8667 5 12.3333 5.46667 12.3333 6C12.3333 6.53333 11.8667 7 11.3333 7Z'} fill={stringToColour(ens || `${truncateHex(address, 5)}`)}/>
 				</svg>
-				<span className={'hidden lg:block'}>{ens || `${truncateHex(address, 5)}`}</span>
+				<span className={'hidden md:block'}>{ens || `${truncateHex(address, 5)}`}</span>
 			</p>
 		);
 	}
@@ -98,7 +98,7 @@ function	Navbar({router}) {
 					{router.route === '/' ? 
 						<select
 							value={chainID}
-							className={'m-0 mr-2 hidden cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-400 bg-neutral-0 px-3 py-2 pr-7 font-mono text-xs font-semibold leading-4 text-neutral-700 sm:max-md:flex lg:flex'}
+							className={'m-0 mr-2 hidden cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-400 bg-neutral-0 px-3 py-2 pr-7 font-mono text-xs font-semibold leading-4 text-neutral-700 md:flex'}
 							onChange={e => onSwitchChain(e.target.value)}>
 							{Object.values(chains).map((chain, index) => (
 								<option key={index} value={chain.chainID}>{chain.name}</option>

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -70,7 +70,7 @@ function	Navbar({router}) {
 				suppressHydrationWarning
 				className={'inline-flex cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-400 bg-neutral-0 px-3 py-2 font-mono text-xs font-semibold leading-4 text-neutral-700'}>
 				<svg
-					className={'mr-0 md:mr-2'}
+					className={'mr-0 lg:mr-2'}
 					width={'16'}
 					height={'16'}
 					viewBox={'0 0 16 16'}
@@ -78,7 +78,7 @@ function	Navbar({router}) {
 					xmlns={'http://www.w3.org/2000/svg'}>
 					<path d={'M12.6667 0H3.33333C1.46667 0 0 1.46667 0 3.33333V12.6667C0 14.5333 1.46667 16 3.33333 16H12.6667C14.5333 16 16 14.5333 16 12.6667V3.33333C16 1.46667 14.5333 0 12.6667 0ZM4.66667 5C5.2 5 5.66667 5.46667 5.66667 6C5.66667 6.53333 5.2 7 4.66667 7C4.13333 7 3.66667 6.53333 3.66667 6C3.66667 5.46667 4.13333 5 4.66667 5ZM12.0667 10.4C10.9333 11.4667 9.46667 12.0667 8 12.0667C6.53333 12.0667 5 11.4667 3.93333 10.4C3.8 10.2667 3.73333 10.1333 3.73333 9.93333C3.73333 9.53333 4 9.26667 4.4 9.26667C4.6 9.26667 4.73333 9.33333 4.86667 9.46667C5.73333 10.3333 6.86667 10.8 8 10.8C9.13333 10.8 10.2667 10.3333 11.1333 9.46667C11.2667 9.33333 11.4 9.26667 11.6 9.26667C12 9.26667 12.2667 9.53333 12.2667 9.93333C12.2667 10.1333 12.2 10.2667 12.0667 10.4ZM11.3333 7C10.8 7 10.3333 6.53333 10.3333 6C10.3333 5.46667 10.8 5 11.3333 5C11.8667 5 12.3333 5.46667 12.3333 6C12.3333 6.53333 11.8667 7 11.3333 7Z'} fill={stringToColour(ens || `${truncateHex(address, 5)}`)}/>
 				</svg>
-				<span className={'hidden md:block'}>{ens || `${truncateHex(address, 5)}`}</span>
+				<span className={'hidden lg:block'}>{ens || `${truncateHex(address, 5)}`}</span>
 			</p>
 		);
 	}
@@ -98,7 +98,7 @@ function	Navbar({router}) {
 					{router.route === '/' ? 
 						<select
 							value={chainID}
-							className={'m-0 mr-2 hidden cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-400 bg-neutral-0 px-3 py-2 pr-7 font-mono text-xs font-semibold leading-4 text-neutral-700 md:flex'}
+							className={'m-0 mr-2 hidden cursor-pointer items-center whitespace-nowrap border border-solid border-neutral-400 bg-neutral-0 px-3 py-2 pr-7 font-mono text-xs font-semibold leading-4 text-neutral-700 sm:max-md:flex lg:flex'}
 							onChange={e => onSwitchChain(e.target.value)}>
 							{Object.values(chains).map((chain, index) => (
 								<option key={index} value={chain.chainID}>{chain.name}</option>

--- a/pages/index.js
+++ b/pages/index.js
@@ -186,11 +186,11 @@ function	Index() {
 	return (
 		<main className={'max-w-5xl'}>
 			<div>
-				<div className={'hidden md:block'}>
+				<div className={'hidden lg:block'}>
 					<h1 className={'mb-6 font-mono text-3xl font-semibold leading-9 text-neutral-900'}>{'Experimental Experiments Registry'}</h1>
 				</div>
-				<div className={'flex md:hidden'}>
-					<h1 className={'font-mono text-xl font-semibold leading-9 text-neutral-900'}>{'Ex'}<sup className={'mt-4 mr-2'}>{'2'}</sup>{' Registry'}</h1>
+				<div className={'flex lg:hidden'}>
+					<h1 className={'font-mono text-xl font-semibold leading-9 text-neutral-900 md:text-3xl'}>{'Ex'}<sup className={'mr-2 mt-4'}>{'2'}</sup>{' Registry'}</h1>
 				</div>
 			</div>
 			<div className={'my-4 max-w-5xl bg-yellow-900 p-4 font-mono text-sm font-normal text-[#485570]'}>


### PR DESCRIPTION
## Description

This PR has the purpose of improving the header of home page.  Currently, some nav components are overflowing the title when the available screen size decreases.

To address this, I applied media queries to the nav buttons. It was the first change that came to my mind, since I didn’t want to affect the title design and it appears to work.

## Related Issue

resolves #203 

## Motivation and Context

The intention to apply this change is solve the issue suggested and make the header look better on small screens.

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that everything appeared as expected

## Resources (if appropriate):

<img width="767" alt="Screenshot 2023-05-26 at 7 50 09 PM" src="https://github.com/saltyfacu/ape-tax/assets/104786213/3a2da8bc-7bcb-486f-ac97-bdb818d8780d">
