### PR TITLE
fix: Adjust variable name to resolve button functionality

### DIFF
--- a/pages/[slug]/index.js
+++ b/pages/[slug]/index.js
@@ -11,7 +11,7 @@ import {toAddress} from '@yearn-finance/web-lib/utils/address';
 import {getProvider} from '@yearn-finance/web-lib/utils/web3/providers';
 
 function Wrapper({vault, slug, prices}) {
-	const	{provider, isActive, address, ens, chainID, openModalLogin} = useWeb3();
+	const	{provider, isActive, address, ens, chainID, openLoginModal} = useWeb3();
 	const	{communityVaults} = useFactory();
 	const	[currentVault, set_currentVault] = React.useState(vault);
 	const	windowInFocus = useWindowInFocus();
@@ -75,7 +75,7 @@ function Wrapper({vault, slug, prices}) {
 					<p className={'font-mono text-4xl font-medium leading-11'}>{'❌🔌'}</p>
 					<p className={'font-mono text-4xl font-medium leading-11 text-neutral-900'}>{'Not connected'}</p>
 					<button
-						onClick={openModalLogin}
+						onClick={openLoginModal}
 						className={'bg-neutral-50 mt-8 border border-solid border-neutral-500 p-1.5 font-mono text-sm font-medium transition-colors hover:bg-neutral-100'}>
 						{'🔌 Connect wallet'}
 					</button>


### PR DESCRIPTION
## Description

This PR has the purpose of correcting a typo in the `openLoginModal` variable of the web-lib library used in the button of 'connect wallet'. This error makes the button not meet the functionality expected (see image below).

     openModalLogin changed to openLoginModal

## Motivation and Context

The motivation is to fix a small typo. After to apply this change, it's expected that this button to work correctly and that the user can through a click, connect their wallet in a simple way.

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that the button works as expected.

## Resources (if appropriate):
<img width="837" alt="Screenshot 2023-05-26 at 1 36 54 PM" src="https://github.com/saltyfacu/ape-tax/assets/104786213/ea293656-7d66-400b-b526-f0803be153e3">
