### PR TITLE
refactor: Update react imports

### DIFF
--- a/components/AddressWithAction.tsx
+++ b/components/AddressWithAction.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useSettings} from '@yearn-finance/web-lib/contexts/useSettings';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import IconCopy from '@yearn-finance/web-lib/icons/IconCopy';

--- a/components/AnimatedWait.tsx
+++ b/components/AnimatedWait.tsx
@@ -1,5 +1,4 @@
-
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 
 import type {ReactElement} from 'react';
 

--- a/components/InfoMessage.tsx
+++ b/components/InfoMessage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type {ReactElement} from 'react';
 
 function	InfoMessage({status}: {status: string}): ReactElement {

--- a/components/Meta.tsx
+++ b/components/Meta.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Head from 'next/head';
 import {DefaultSeo} from 'next-seo';
 import meta from 'public/manifest.json';

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useState} from 'react';
+import {Fragment, useState} from 'react';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';

--- a/components/Suspense.tsx
+++ b/components/Suspense.tsx
@@ -1,4 +1,3 @@
-import	React					from	'react';
 import	AnimatedWait			from	'components/AnimatedWait';
 
 import type {ReactElement, ReactNode} from 'react';

--- a/components/VaultActions.tsx
+++ b/components/VaultActions.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useState} from 'react';
+import {Fragment, useState} from 'react';
 import {ethers} from 'ethers';
 import {apeInVault, apeOutVault, approveToken, depositToken, withdrawToken} from 'utils/actions';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';

--- a/components/VaultDetails.tsx
+++ b/components/VaultDetails.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import ProgressChart from 'components/ProgressChart';
 import Suspense from 'components/Suspense';
 import useSWR from 'swr';

--- a/components/VaultStrategies.tsx
+++ b/components/VaultStrategies.tsx
@@ -1,5 +1,4 @@
-
-import React, {Fragment, useCallback, useEffect, useState} from 'react';
+import {Fragment, useCallback, useEffect, useState} from 'react';
 import {Contract} from 'ethcall';
 import {ethers} from 'ethers';
 import YVAULT_ABI from 'utils/ABI/yVault.abi.json';

--- a/components/VaultWallet.tsx
+++ b/components/VaultWallet.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import {toAddress, truncateHex} from '@yearn-finance/web-lib/utils/address';
 import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';

--- a/components/VaultWrapper.tsx
+++ b/components/VaultWrapper.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import InfoMessage from 'components/InfoMessage';
 import VaultActions from 'components/VaultActions';
 import VaultDetails from 'components/VaultDetails';

--- a/contexts/useBalancerGauges.tsx
+++ b/contexts/useBalancerGauges.tsx
@@ -1,4 +1,4 @@
-import React, {createContext, useCallback, useContext, useEffect, useState} from 'react';
+import {createContext, useCallback, useContext, useEffect, useState} from 'react';
 import {Contract} from 'ethcall';
 import {request} from 'graphql-request';
 import AURA_BOOSTER_ABI from 'utils/ABI/auraBooster.abi.json';

--- a/contexts/useFactory.tsx
+++ b/contexts/useFactory.tsx
@@ -1,4 +1,4 @@
-import React, {createContext, useCallback, useContext, useEffect, useState} from 'react';
+import {createContext, useCallback, useContext, useEffect, useState} from 'react';
 import {Contract} from 'ethcall';
 import FACTORY_ABI from 'utils/ABI/factory.abi.json';
 import YVAULT_ABI from 'utils/ABI/yVault.abi.json';

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,5 +1,3 @@
-import	React	from	'react';
-
 import type {ReactElement} from 'react';
 
 function Error404(): ReactElement {

--- a/pages/[slug]/index.tsx
+++ b/pages/[slug]/index.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useCallback, useState} from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import {NextSeo} from 'next-seo';
 import VaultWrapper from 'components/VaultWrapper';
 import {useFactory} from 'contexts/useFactory';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Meta from 'components/Meta';
 import Navbar from 'components/Navbar';
 import {BalancerGaugeContextApp} from 'contexts/useBalancerGauges';

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Document, {Head, Html, Main, NextScript} from 'next/document';
 
 import type {DocumentContext, DocumentInitialProps} from 'next/document';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useEffect, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import Link from 'next/link';
 import {useFactory} from 'contexts/useFactory';
 import {ethers} from 'ethers';

--- a/pages/newVault.tsx
+++ b/pages/newVault.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useCallback, useEffect, useState} from 'react';
+import {Fragment, useCallback, useEffect, useState} from 'react';
 import {AddressWithActions} from 'components/AddressWithAction';
 import {useBalancerGauge} from 'contexts/useBalancerGauges';
 import {useFactory} from 'contexts/useFactory';


### PR DESCRIPTION
## Description

This PR has the purpose adjust and remove unnecessary react imports in this repo.

In these cases:

     import React, {useEffect, useState} from 'react';

The first 'React' was removed leaving only the hooks or complements:

    import {useEffect, useState} from 'react';

and lines that only imported React from 'react', they were removed.

Extra: Fixed some warnings "Invalid Tailwind CSS classnames order".

## Related Issue

N/A

## Motivation and Context

The motivation by removing unnecessary imports is to keep the code as clean as possible.  Directly importing react used to be required but for a while now it hasn't been. 

## How Has This Been Tested?

After making the changes I ran 'yarn dev' and confirmed that there was no error or loss of functionality, everything appeared as expected.

## Resources

Reference: [The New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)