### PR TITLE
fix: Resolve infinite load on vault APRs

### DIFF
--- a/components/VaultDetails.tsx
+++ b/components/VaultDetails.tsx
@@ -76,7 +76,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 				<div>
 					<p className={'inline text-neutral-900'}>{'Gross APR (last week): '}</p>
 					<p className={'ml-3 inline text-neutral-700'}>
-						<Suspense wait={!!vaultAPY && !isLoading}>
+						<Suspense wait={!vaultAPY && isLoading}>
 							{`${vaultAPY?.week || '-'}`}
 						</Suspense>
 					</p>
@@ -84,7 +84,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 				<div>
 					<p className={'inline text-neutral-900'}>{'Gross APR (last month): '}</p>
 					<p className={'ml-3 inline text-neutral-700'}>
-						<Suspense wait={!!vaultAPY && !isLoading}>
+						<Suspense wait={!vaultAPY && isLoading}>
 							{`${vaultAPY?.month || '-'}`}
 						</Suspense>
 					</p>
@@ -92,7 +92,7 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 				<div>
 					<p className={'inline text-neutral-900'}>{'Gross APR (inception): '}</p>
 					<p className={'ml-3 inline text-neutral-700'}>
-						<Suspense wait={!!vaultAPY && !isLoading}>
+						<Suspense wait={!vaultAPY && isLoading}>
 							{`${vaultAPY?.inception || '-'}`}
 						</Suspense>
 					</p>


### PR DESCRIPTION
The suspense condition was causing loading to go on forever, slight adjustment corrected this.

I tested by entering a few vaults after making the change and I believe the loading is now happening as intended, no flicker, just loading then values as soon as they're available. 