### PR TITLE
chore: Add script ‘lintfix’

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "tsc && next build",
     "export": "tsc && next build && next export -o ipfs",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lintfix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "bump": "bump"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

The `lintfix` script was added to facilitate the automatically fixes the trivial warnings identified after lint script run. These fixes are made directly in the code according to the rules set at the web-lib/.eslintrc.cjs file.

## Motivation and Context

I thought it would be important to suggest this change with the motivation of standardizing the package.json file with that of the yPartners repo and make easily accessible the --fix method of the lint dependency