### PR TITLE
chore: Improve responsiveness of deploy vault button

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -245,9 +245,12 @@ function	Index(): ReactElement {
 						</div>
 					</div>
 				</div>
-				<div className={'flex items-center'}>
+				<div className={'flex items-center max-sm:justify-center md:justify-start'}>
 					<Link href={'/newVault'}>
-						<span className={'cursor-pointer border border-dashed border-neutral-500 bg-neutral-200 px-4 py-2 font-mono text-sm text-neutral-700 transition-colors hover:bg-neutral-0'}>
+						<span className={'flex cursor-pointer border border-dashed border-neutral-500 bg-neutral-200 px-4 py-2 font-mono text-sm text-neutral-700 transition-colors hover:bg-neutral-0 md:hidden'}>
+							{'🏦 Deploy vault'}
+						</span>
+						<span className={'hidden cursor-pointer border border-dashed border-neutral-500 bg-neutral-200 px-4 py-2 font-mono text-sm text-neutral-700 transition-colors hover:bg-neutral-0 md:block'}>
 							{'🏦 Deploy your own vault'}
 						</span>
 					</Link>


### PR DESCRIPTION
## Description

This PR has the purpose to adjust the size of the `🏦 Deploy your own vault` button in the pages of the vaults when the available screen size decreases. I applied media queries to improve the appearance of the button as the issue suggests.

## Related Issue

resolves #211 

## Motivation and Context

Currently, button doesn't look quite as nice on small screens. The intention is solve the issue and make the button look nice on different screen sizes.

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that the button appeared as expected. 

## Resources (if appropriate):

N/A