### PR TITLE
fix: Solve dependency warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@gnosis.pm/gp-v2-contracts": "^1.1.2",
     "@headlessui/react": "^1.7.14",
     "@next/bundle-analyzer": "^13.4.1",
-    "@next/font": "^13.4.1",
     "@react-hookz/deep-equal": "^1.0.4",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/typography": "^0.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,11 +1618,6 @@
   dependencies:
     glob "7.1.7"
 
-"@next/font@^13.4.1":
-  version "13.4.5"
-  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.4.5.tgz#c720fc2196557aa34330985de46a513688c9adcc"
-  integrity sha512-pjgtnnyamcFK9rv/WKr9WDmVBcd50VK4zZX9E846jowRm8FadjiumDOV80elXUtYW9GXSpAiqWqNMw/kVXNuQQ==
-
 "@next/swc-darwin-arm64@13.4.5":
   version "13.4.5"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.5.tgz#54eb1fb2521a18e1682214c416cc44f3721dd9c8"


### PR DESCRIPTION
## Description
The purpose to this pull request is to solve a warning present in the terminal.

After executing `yarn dev` you can observe the following warning in the terminal:

⚠️ warn Your project has `@next/font` installed as a dependency, please use the built-in `next/font` instead. The `@next/font` package will be removed in Next.js 14. You can migrate by running `npx @next/codemod@latest built-in-next-font`. Read more: https://nextjs.org/docs/messages/built-in-next-font

## Related Issue
N/A

## Motivation and Context

To solve this warning, I removed the @next/font package since it is now built into next.js itself. 

## How Has This Been Tested?

I confirmed that the warning was no longer present after making the change.

## Resources (if appropriate):

N/A



