### PR TITLE
fix: Solve compiler warning

### DIFF
--- a/components/Meta.tsx
+++ b/components/Meta.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Script from 'next/script';
 import {DefaultSeo} from 'next-seo';
 import meta from 'public/manifest.json';
 
@@ -32,16 +33,17 @@ function Meta(): ReactElement {
 					color={meta.theme_color} />
 
 				<link rel={'icon'} href={'data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧠</text></svg>'} />
-
-				<script
-					defer
-					data-domain={'ape.tax'}
-					src={'/js/script.js'}/>
 					
 				<meta name={'robots'} content={'index,nofollow'} />
 				<meta name={'googlebot'} content={'index,nofollow'} />
 				<meta charSet={'utf-8'} />
 			</Head>
+			
+			<Script
+				defer
+				data-domain={'ape.tax'}
+				src={'/js/script.js'}/>
+
 			<DefaultSeo
 				title={meta.name}
 				defaultTitle={meta.name}


### PR DESCRIPTION
## Description

The purpose to this PR is to fix a warning in the repo.

This warning is being logged in the terminal, after running `yarn dev`:

`Do not add <script> tags using next/head (see <script> tag with src="/js/script.js"). Use next/script instead.
See more info here: https://nextjs.org/docs/messages/no-script-tags-in-head-component`

Steps to resolve this warning:

- Imported `Script` from `next/script`.
- Replaced existing <script/> tag by new `<Script>` tag.
- Moved the `<Script />` component outside of `<Head>` instead.

## Related Issue

N/A

## Motivation and Context

The intention to apply this change is fix current warning in the terminal.

## How Has This Been Tested?

After making the changes, I confirmed that the warning indicated above is no longer registered in the terminal when run `yarn dev`.

## Resources

 Reference: 
https://nextjs.org/docs/messages/no-script-component-in-head
https://nextjs.org/docs/messages/no-script-tags-in-head-component

