### PR TITLE
chore: Adjust the Deposit Limit condition in the vault details section

### DIFF
--- a/components/VaultDetails.tsx
+++ b/components/VaultDetails.tsx
@@ -3,6 +3,7 @@ import ProgressChart from 'components/ProgressChart';
 import Suspense from 'components/Suspense';
 import {useChain} from 'hook/useChain';
 import useSWR from 'swr';
+import {MAX_UINT_256} from '@yearn-finance/web-lib/utils/constants';
 import {baseFetcher} from '@yearn-finance/web-lib/utils/fetchers';
 import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';
 import {isZero} from '@yearn-finance/web-lib/utils/isZero';
@@ -53,7 +54,9 @@ function	VaultDetails({vault, vaultData}: {vault: TVault, vaultData: TVaultData}
 					<p className={'inline text-neutral-900'}>{'Deposit Limit: '}</p>
 					<p className={'ml-3 inline text-neutral-700'}>
 						<Suspense wait={!vaultData.loaded}>
-							{`${isZero(vaultData.depositLimit.raw) ? '-' : formatAmount(vaultData?.depositLimit.normalized, 2)} ${vault.WANT_SYMBOL}`}
+							{isZero(vaultData.depositLimit.raw) ? '-' :
+								vaultData.depositLimit.raw === MAX_UINT_256 ? `∞ ${vault.WANT_SYMBOL}` :
+									`${formatAmount(vaultData?.depositLimit.normalized, 2)} ${vault.WANT_SYMBOL}`}
 						</Suspense>
 					</p>
 				</div>


### PR DESCRIPTION
## Description

The purpose of this PR is update the condition of the Deposit Limit of the vault details section, showing `∞` in the specific case when the limit of the vault is the greatest possible.

## Related Issue

resolves #220

## Motivation and Context

The intention to apply this change is solve the issue and improve the user experience for this specific case. 

## How Has This Been Tested?

After adjusting this condition, I ran `yarn dev` with the test suggested in the issue and I confirmed that showed 'Deposit Limit:  ∞'  as expected.

## Resources

N/A