### PR TITLE
refactor: Comment unused types

### DIFF
--- a/utils/types.tsx
+++ b/utils/types.tsx
@@ -27,35 +27,35 @@ export type TVault = {
 	ZAP_ADDR?: string;
 }
 
-export type TAPIVault = {
-	title: string;
-	logo: string;
-	displayName: string;
-	src: string;
-	status: string;
-	type: string;
-	address: string;
-	network: number;
-	APY?: {
-		week: string;
-		month: string;
-		inception: string;
-	}
-	data: {
-		apiVersion: string;
-		depositLimit: string;
-		totalAssets: string;
-		availableDepositLimit: string;
-		pricePerShare: string;
-		decimals: number;
-		activation: number;
-	};
-	want: {
-		address: string;
-		symbol: string;
-		cgID: string;
-	};
-}
+// export type TAPIVault = {
+// 	title: string;
+// 	logo: string;
+// 	displayName: string;
+// 	src: string;
+// 	status: string;
+// 	type: string;
+// 	address: string;
+// 	network: number;
+// 	APY?: {
+// 		week: string;
+// 		month: string;
+// 		inception: string;
+// 	}
+// 	data: {
+// 		apiVersion: string;
+// 		depositLimit: string;
+// 		totalAssets: string;
+// 		availableDepositLimit: string;
+// 		pricePerShare: string;
+// 		decimals: number;
+// 		activation: number;
+// 	};
+// 	want: {
+// 		address: string;
+// 		symbol: string;
+// 		cgID: string;
+// 	};
+// }
 
 export type TSpecificAPIResult = {
 	week: string;
@@ -105,10 +105,10 @@ export type TTVL = {
 	tvl: number;
 }
 
-export type TGauge = {
-	address: TAddress,
-	name: string,
-	symbol: string,
-	exists: boolean,
-	isAuraOK: boolean,
-}
+// export type TGauge = {
+// 	address: TAddress,
+// 	name: string,
+// 	symbol: string,
+// 	exists: boolean,
+// 	isAuraOK: boolean,
+// }


### PR DESCRIPTION
## Description

Currently, there are types we don’t use in the repo. The intention of this PR is comment them out and we can decide if we want to remove them later.

## Related Issue
N/A

## Motivation and Context

Ensure that only types currently used in the repo are enabled. 

## How Has This Been Tested?

N/A

## Resources

N/A