### PR TITLE
refactor: Standardize the structure of the conditionals 

### DIFF
--- a/utils/utils.tsx
+++ b/utils/utils.tsx
@@ -29,28 +29,43 @@ export async function fetchBlockTimestamp(timestamp: number, network = 1): TFetc
 	}
 
 	if (network === 137) {
-		const baseURL = 'https://api.polygonscan.com/api?module=block&action=getblocknobytime&timestamp';
+		const blockTimestampQueryParams = new URLSearchParams({
+			module: 'block',
+			action: 'getblocknobytime',
+			timestamp: timestamp.toString(),
+			closest:'before',
+			apikey: process.env.POLYGONSCAN_API || ''
+		});
 
 		return fetch<TBlockTimestampDetails>({
-			endpoint: `${baseURL}=${new URLSearchParams(`${timestamp}`)}&closest=before&apikey=${process.env.POLYGONSCAN_API}`,
+			endpoint: `https://api.polygonscan.com/api?=${new URLSearchParams(blockTimestampQueryParams)}`,
 			schema: blockTimestampResponseSchema
 		});
 	}
 
 	if (network === 42161) {
-		const baseURL = 'https://api.arbiscan.io/api?module=block&action=getblocknobytime&timestamp';
-
+		const blockTimestampQueryParams = new URLSearchParams({
+			module: 'block',
+			action: 'getblocknobytime',
+			timestamp: timestamp.toString(),
+			closest:'before',
+			apikey: process.env.ETHERSCAN_API || ''
+		});
 		return fetch<TBlockTimestampDetails>({
-			endpoint: `${baseURL}=${new URLSearchParams(`${timestamp}`)}&closest=before&apikey=${process.env.ETHERSCAN_API}`,
+			endpoint: `https://api.arbiscan.io/api?=${new URLSearchParams(blockTimestampQueryParams)}`,
 			schema: blockTimestampResponseSchema
 		});
 	}
 
-
-	const baseURL = 'https://api.etherscan.io/api?module=block&action=getblocknobytime&timestamp';
-				
+	const blockTimestampQueryParams = new URLSearchParams({
+		module: 'block',
+		action: 'getblocknobytime',
+		timestamp: timestamp.toString(),
+		closest:'before',
+		apikey: process.env.ETHERSCAN_API || ''
+	});		
 	return fetch<TBlockTimestampDetails>({
-		endpoint: `${baseURL}=${new URLSearchParams(`${timestamp}`)}&closest=before&apikey=${process.env.ETHERSCAN_API}`,
+		endpoint: `https://api.etherscan.io/api?=${new URLSearchParams(blockTimestampQueryParams)}`,
 		schema: blockTimestampResponseSchema
 	});
 }


### PR DESCRIPTION
## Description

The purpose of this PR is to make the all api endpoints of the function are more readable. This change is made taking as an example the structure of the first conditional, where the ‘URLSearchParams' object is used to divide the string into pieces for easily understood.

## Related Issue

N/A

## Motivation and Context

The motivation to apply this change is to standardize the structure of the conditionals and allow the api endpoints more readable.

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that everything appeared as expected

## Resources

N/A