### PR TITLE
refactor: Media query adjustments and UI improvements

### DIFF
--- a/components/InfoMessage.tsx
+++ b/components/InfoMessage.tsx
@@ -17,7 +17,7 @@ function	InfoMessage({status}: {status: string}): ReactElement {
 	}
 	return (
 		<div className={'my-4 max-w-5xl bg-yellow-900 p-4 font-mono text-sm font-normal text-[#485570]'}>
-			{'⚠️ '}<strong>{'WARNING'}</strong> {"this experiments are experimental. It's extremely risky and will probably be discarded when the test is over. Proceed with extreme caution."}
+			{'⚠️ '}<strong>{'WARNING'}</strong> {"These experiments are experimental. It's extremely risky and will probably be discarded when the test is over. Proceed with extreme caution."}
 		</div>
 	);
 }

--- a/components/VaultActions.tsx
+++ b/components/VaultActions.tsx
@@ -117,15 +117,15 @@ function	VaultActionZaps({vault, vaultData, onUpdateVaultData, onProceed}: TVaul
 			<div className={vault.VAULT_STATUS === 'withdraw' ? 'hidden' : ''}>
 				<div className={'mb-2 mr-2 flex flex-row items-center'} style={{height: '33px'}}>
 					<input
-						className={'border-neutral-500 bg-neutral-0/0 px-2 py-1.5 font-mono text-xs text-neutral-500'}
-						style={{height: '33px', backgroundColor: 'rgba(0,0,0,0)'}}
+						className={'border-neutral-500 bg-neutral-0/0 px-2 py-1.5 text-xs text-neutral-900'}
+						style={{height: '33px'}}
 						type={'text'}
 						value={zapAmount?.normalized}
 						onChange={(e: ChangeEvent<HTMLInputElement>): void => set_zapAmount(
 							handleInputChangeEventValue(e.target.value, vaultData.decimals)
 						)} />
-					<div className={'bg-neutral-50 border border-l-0 border-solid border-neutral-500 px-2 py-1.5 font-mono text-xs text-neutral-400'} style={{height: '33px'}}>
-						{chainCoin}&nbsp;
+					<div className={'border border-l-0 border-solid border-neutral-500 bg-neutral-100 px-2 py-1.5 text-xs'} style={{height: '33px'}}>
+						{chainCoin}
 					</div>
 				</div>
 			</div>
@@ -136,14 +136,13 @@ function	VaultActionZaps({vault, vaultData, onUpdateVaultData, onProceed}: TVaul
 							<button
 								onClick={onZapIn}
 								disabled={isZapIn || isZero(zapAmount.raw)}
-								className={`${isZapIn || isZero(zapAmount.raw) ? 'bg-neutral-50 cursor-not-allowed opacity-30' : 'bg-neutral-50 hover:bg-neutral-100'} mb-2 mr-8 border border-solid border-neutral-500 p-1.5 font-mono text-sm font-semibold transition-colors`}>
+								className={`${isZapIn || isZero(zapAmount.raw) ? 'bg-neutral-50 cursor-not-allowed opacity-30' : 'bg-neutral-50 hover:bg-neutral-100'} mb-2 mr-8 w-[6rem] border border-solid border-neutral-500 p-1.5 text-sm font-semibold text-neutral-900 transition-colors`}>
 								{'💰 Zap in'}
 							</button>
 						</> : <Fragment />
 				}
 				<Button
 					variant={'outlined'}
-					className={'bg-neutral-50 mb-2 mr-2 border border-solid border-neutral-500 p-1.5 font-mono text-sm font-semibold transition-colors hover:bg-neutral-100'}
 					isBusy={txStatusZapApproval.pending}
 					isDisabled={txStatusZapApproval.error || txStatusZapApproval.pending || (vaultData.allowanceZapOut && vaultData?.allowanceZapOut?.raw > 0n)}
 					onClick={onZapOutAllowance}>
@@ -152,7 +151,7 @@ function	VaultActionZaps({vault, vaultData, onUpdateVaultData, onProceed}: TVaul
 				<button
 					onClick={onZapOut}
 					disabled={isZero(vaultData.balanceOf.raw) || isZero(vaultData?.allowanceZapOut?.raw)}
-					className={`${isZero(vaultData.balanceOf.raw) || isZero(vaultData?.allowanceZapOut?.raw) ? 'bg-neutral-50 cursor-not-allowed opacity-30' : 'bg-neutral-50 hover:bg-neutral-100'} mb-2 mr-2 border border-solid border-neutral-500 p-1.5 font-mono text-sm font-semibold transition-colors`}>
+					className={`${isZero(vaultData.balanceOf.raw) || isZero(vaultData?.allowanceZapOut?.raw) ? 'bg-neutral-50 cursor-not-allowed opacity-30' : 'bg-neutral-50 hover:bg-neutral-100'} mb-2 mr-2 border border-solid border-neutral-500 p-1.5 text-sm font-semibold text-neutral-900 transition-colors`}>
 					{'💸 Zap out'}
 				</button>
 			</div>
@@ -234,25 +233,25 @@ function	VaultActionApeIn({vault, vaultData, onUpdateVaultData, onProceed}: TVau
 	return (
 		<div className={'flex w-full flex-col border border-dashed border-neutral-500 p-4'}>
 			<div className={'mb-2'}>
-				<p className={'font-mono text-xl font-semibold text-neutral-700'}>
+				<p className={'text-xl font-semibold text-neutral-900'}>
 					{'Deposit'}
 				</p>
 			</div>
-			<div className={'mb-6 font-mono text-sm font-medium text-neutral-500'}>
+			<div className={'mb-6 text-sm font-medium'}>
 				<div>
-					<p className={'inline text-neutral-700'}>{`Your ${vault.WANT_SYMBOL} Balance: `}</p>
-					<p className={'inline text-neutral-500'}>{`${formatAmount(vaultData?.wantBalance.normalized, 6)}`}</p>
+					<p className={'inline text-neutral-900'}>{`Your ${vault.WANT_SYMBOL} Balance: `}</p>
+					<p className={'ml-3 inline'}>{`${formatAmount(vaultData?.wantBalance.normalized, 6)}`}</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-700'}>{`Your ${chainCoin} Balance: `}</p>
-					<p className={'inline text-neutral-500'}>{`${formatAmount(vaultData?.coinBalance.normalized, 2)}`}</p>
+					<p className={'inline text-neutral-900'}>{`Your ${chainCoin} Balance: `}</p>
+					<p className={'ml-3 inline'}>{`${formatAmount(vaultData?.coinBalance.normalized, 2)}`}</p>
 				</div>
 			</div>
 
 			<div className={'mb-2 flex w-full flex-row items-center'} style={{height: '33px'}}>
 				<input
-					className={'w-full border-neutral-500 bg-neutral-0/0 px-2 py-1.5 font-mono text-xs text-neutral-900'}
-					style={{height: '33px', backgroundColor: 'rgba(0,0,0,0)'}}
+					className={'w-full border-neutral-500 bg-neutral-0/0 px-2 py-1.5 text-xs text-neutral-900'}
+					style={{height: '33px'}}
 					type={'text'}
 					value={amount?.normalized}
 					onChange={(e: ChangeEvent<HTMLInputElement>): void => set_amount(
@@ -260,7 +259,7 @@ function	VaultActionApeIn({vault, vaultData, onUpdateVaultData, onProceed}: TVau
 					)} />
 				<button
 					onClick={(): void => set_amount(vaultData.wantBalance)}
-					className={'border border-l-0 border-solid border-neutral-500 bg-neutral-100 px-2 py-1.5 font-mono text-xs text-neutral-700 transition-colors hover:bg-neutral-900 hover:text-neutral-0'}
+					className={'border border-l-0 border-solid border-neutral-500 bg-neutral-100 px-2 py-1.5 text-xs transition-colors hover:bg-neutral-900 hover:text-neutral-0'}
 					style={{height: '33px'}}>
 					{'max'}
 				</button>
@@ -375,26 +374,26 @@ function	VaultActionApeOut({vault, vaultData, onUpdateVaultData, onProceed}: TVa
 	return (
 		<div className={'flex w-full flex-col border border-dashed border-neutral-500 p-4'}>
 			<div className={'mb-2'}>
-				<p className={'font-mono text-xl font-semibold text-neutral-700'}>
+				<p className={'text-xl font-semibold text-neutral-900'}>
 					{'Withdraw'}
 				</p>
 			</div>
-			<div className={'mb-6 font-mono text-sm font-medium text-neutral-500'}>
+			<div className={'mb-6 text-sm font-medium'}>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Your vault shares: '}</p>
-					<p className={'inline text-neutral-500'}>{`${formatAmount(vaultData?.balanceOf.normalized, 6)}`}</p>
+					<p className={'inline text-neutral-900'}>{'Your vault shares: '}</p>
+					<p className={'ml-3 inline'}>{`${formatAmount(vaultData?.balanceOf.normalized, 6)}`}</p>
 				</div>
 				<div>
-					<p className={'inline text-neutral-700'}>{'Your shares value: '}</p>
-					<p className={'inline text-neutral-500'}>{`$${vaultData.balanceOfValue === 0 ? '-' : formatAmount(vaultData?.balanceOfValue, 2)}`}</p>
+					<p className={'inline text-neutral-900'}>{'Your shares value: '}</p>
+					<p className={'ml-3 inline'}>{`$${vaultData.balanceOfValue === 0 ? '-' : formatAmount(vaultData?.balanceOfValue, 2)}`}</p>
 				</div>
 			</div>
 
 			<div className={'mb-2 flex w-full flex-row items-center'} style={{height: '33px'}}>
 				<input
-					className={'w-full border-neutral-500 bg-neutral-0/0 px-2 font-mono text-xs text-neutral-900'}
+					className={'w-full border-neutral-500 bg-neutral-0/0 px-2 text-xs text-neutral-900'}
 					disabled={vault.VAULT_STATUS === 'withdraw'}
-					style={{height: '33px', backgroundColor: 'rgba(0,0,0,0)'}}
+					style={{height: '33px'}}
 					type={'text'}
 					value={amount?.normalized}
 					onChange={(e: ChangeEvent<HTMLInputElement>): void => set_amount(
@@ -402,7 +401,7 @@ function	VaultActionApeOut({vault, vaultData, onUpdateVaultData, onProceed}: TVa
 					)} />
 				<button
 					onClick={(): void => set_amount(toNormalizedBN(vaultData.balanceOf.raw, vaultData.decimals))}
-					className={'border border-l-0 border-solid border-neutral-500 bg-neutral-100 px-2 py-1.5 font-mono text-xs text-neutral-700 transition-colors hover:bg-neutral-900 hover:text-neutral-0'}
+					className={'border border-l-0 border-solid border-neutral-500 bg-neutral-100 px-2 py-1.5 text-xs transition-colors hover:bg-neutral-900 hover:text-neutral-0'}
 					style={{height: '33px'}}>
 					{'max'}
 				</button>
@@ -512,9 +511,9 @@ function	VaultAction({vault, vaultData, onUpdateVaultData}: TVaultAction): React
 
 	return (
 		<section aria-label={'ACTIONS'} className={'my-4 mt-8'}>
-			<h1 className={'mb-6 font-mono text-2xl font-semibold text-neutral-900'}>{'APE-IN/OUT'}</h1>
+			<h1 className={'mb-6 text-2xl font-semibold text-neutral-900'}>{'APE-IN/OUT'}</h1>
 			<div className={vault.VAULT_STATUS === 'withdraw' ? '' : 'hidden'}>
-				<p className={'font-mono text-sm font-medium text-neutral-700'}>{'Deposit closed.'}</p>
+				<p className={'text-sm font-medium'}>{'Deposit closed.'}</p>
 			</div>
 
 			{vault.ZAP_ADDR ? <VaultActionZaps
@@ -524,7 +523,7 @@ function	VaultAction({vault, vaultData, onUpdateVaultData}: TVaultAction): React
 				onProceed={fetchPostDepositOrWithdraw}
 			/> : (<Fragment />)}
 
-			<div className={'grid w-full max-w-5xl grid-cols-2 gap-8'}>
+			<div className={'grid max-w-5xl grid-cols-1 gap-8 md:grid-cols-2'}>
 				{vaultData.depositLimit.raw > 0n && vault.VAULT_STATUS !== 'withdraw' ? (
 					<VaultActionApeIn
 						vault={vault}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -29,7 +29,7 @@ function Tag({status}: {status: string}): ReactElement {
 	if (status === 'use_production' || status === 'endorsed') {
 		return (
 			<>
-				<span className={'ml-2 hidden rounded-md bg-[#0657f9] px-2 py-1 font-mono text-xxs text-white lg:inline'}>
+				<span className={'ml-2 hidden rounded-md bg-[#0657f9] px-2 py-1 text-xxs text-white lg:inline'}>
 					<a
 						href={'https://yearn.finance/vaults'}
 						target={'_blank'}
@@ -37,7 +37,7 @@ function Tag({status}: {status: string}): ReactElement {
 						{'Use Production'}
 					</a>
 				</span>
-				<span className={'ml-2 inline rounded-md bg-[#0657f9] px-2 py-1 font-mono text-xxs text-white lg:hidden'}>
+				<span className={'ml-2 inline rounded-md bg-[#0657f9] px-2 py-1 text-xxs text-white lg:hidden'}>
 					<a
 						href={'https://yearn.finance/vaults'}
 						target={'_blank'}
@@ -50,21 +50,21 @@ function Tag({status}: {status: string}): ReactElement {
 	}
 	if (status === 'disabled') {
 		return (
-			<span className={'ml-2 rounded-md bg-yellow-900 px-2 py-1 font-mono text-xxs text-white'}>
+			<span className={'ml-2 rounded-md bg-yellow-900 px-2 py-1 text-xxs text-[#9da0a5]'}>
 				{'Disabled'}
 			</span>
 		);
 	}
 	if (status === 'withdraw') {
 		return (
-			<span className={'ml-2 rounded-md bg-red-900 px-2 py-1 font-mono text-xxs text-white'}>
+			<span className={'ml-2 rounded-md bg-red-900 px-2 py-1 text-xxs text-white'}>
 				{'Withdraw'}
 			</span>
 		);
 	}
 	if (status === 'new') {
 		return (
-			<span className={'ml-2 rounded-md bg-[#10B981] px-2 py-1 font-mono text-xxs text-white'}>
+			<span className={'ml-2 rounded-md bg-[#10B981] px-2 py-1 text-xxs text-white'}>
 				{'New'}
 			</span>
 		);
@@ -77,7 +77,7 @@ function	DisabledVaults({vaultsInactive}: {vaultsInactive: TVault[]}): ReactElem
 		return <Fragment />;
 	}
 	return (
-		<div className={'my-4 max-w-5xl bg-red-900 p-4 pb-2 font-mono text-sm font-normal text-[#485570]'}>
+		<div className={'my-4 max-w-5xl bg-red-900 p-4 pb-2 text-justify text-sm font-normal text-[#485570]'}>
 			{'⚠️ '}<strong>{'WARNING'}</strong>{' 🚨 '}<strong>{'YOU ARE USING DEPRECATED VAULTS'}</strong> {'You have funds in deprecated vaults. Theses vaults are no longer generating any profit and are now an image from the past. Please remove your funds from these vaults.'}
 			<div className={'mt-4'}>
 				<ul className={'grid grid-cols-2 gap-2'}>
@@ -92,7 +92,7 @@ function	DisabledVaults({vaultsInactive}: {vaultsInactive: TVault[]}): ReactElem
 											))
 										}
 									</span>
-									<span className={'dashed-underline-white ml-4 cursor-pointer font-mono text-base font-normal text-[#485570]'}>
+									<span className={'dashed-underline-white ml-4 cursor-pointer text-base font-normal text-[#485570]'}>
 										{vault.TITLE}
 									</span>
 								</div>
@@ -202,7 +202,7 @@ function	Index(): ReactElement {
 	if (!isActive) {
 		return (
 			<section>
-				<h1 className={'font-mono text-sm font-semibold text-neutral-700'}>{'Not connected to Ex'}<sup>{'2'}</sup>{' 🧪'}</h1>
+				<h1 className={'text-sm font-semibold text-neutral-700'}>{'Not connected to Ex'}<sup>{'2'}</sup>{' 🧪'}</h1>
 			</section>
 		);
 	}
@@ -211,68 +211,70 @@ function	Index(): ReactElement {
 		<main className={'max-w-5xl'}>
 			<div>
 				<div className={'hidden lg:block'}>
-					<h1 className={'mb-6 font-mono text-3xl font-semibold leading-9 text-neutral-900'}>{'Experimental Experiments Registry'}</h1>
+					<h1 className={'mb-6 text-3xl font-semibold leading-9 text-neutral-900'}>{'Experimental Experiments Registry'}</h1>
 				</div>
 				<div className={'flex lg:hidden'}>
-					<h1 className={'font-mono text-xl font-semibold leading-9 text-neutral-900 md:text-3xl'}>{'Ex'}<sup className={'mr-2 mt-4'}>{'2'}</sup>{' Registry'}</h1>
+					<h1 className={'text-xl font-semibold leading-9 text-neutral-900 md:text-3xl'}>{'Ex'}<sup className={'mr-2 mt-4'}>{'2'}</sup>{' Registry'}</h1>
 				</div>
 			</div>
-			<div className={'my-4 max-w-5xl bg-yellow-900 p-4 font-mono text-sm font-normal text-[#485570]'}>
+			<div className={'my-4 max-w-5xl bg-yellow-900 p-4 text-justify text-sm font-normal text-[#485570]'}>
 				{'⚠️ '}<strong>{'WARNING'}</strong> {"this experiments are experimental. They are extremely risky and will probably be discarded when the test is over. There's a good chance that you can lose your funds. If you choose to proceed, do it with extreme caution."}
 			</div>
 			<DisabledVaults vaultsInactive={vaultsInactiveForUser} />
 
 			<section aria-label={'TVL & new Vault'} className={'my-8 grid grid-cols-2'}>
 				<div>
-					<div>
-						<span className={'font-mono text-base font-semibold text-neutral-900'}>
+					<div className={'text-base'}>
+						<span className={'font-semibold text-neutral-900'}>
 							{`${chainName || 'Chain'} TVL:`}
 						</span>
-						<span className={'font-mono text-base font-normal text-neutral-700'}>
+						<span className={'font-normal'}>
 							{` $${formatAmount(tvl?.tvl, 2)}`}
 						</span>
 					</div>
 
 					<div className={'text-xs opacity-60'}>
 						<div>
-							<span className={'font-mono font-semibold text-neutral-700'}>
+							<span className={'font-semibold'}>
 								{'Endorsed:'}
 							</span>
-							<span className={'font-mono font-normal text-neutral-700'}>
+							<span className={'font-normal'}>
 								{` $${formatAmount(tvl?.tvlEndorsed, 2)}`}
 							</span>
 						</div>
 						<div>
-							<span className={'font-mono font-semibold text-neutral-700'}>
+							<span className={'font-semibold'}>
 								{'Experimental:'}
 							</span>
-							<span className={'font-mono font-normal text-neutral-700'}>
+							<span className={'font-normal'}>
 								{` $${formatAmount(tvl?.tvlExperimental, 2)}`}
 							</span>
 						</div>
 						<div>
-							<span className={'font-mono font-semibold text-neutral-700'}>
+							<span className={'font-semibold'}>
 								{'Deprecated:'}
 							</span>
-							<span className={'font-mono font-normal text-neutral-700'}>
+							<span className={'font-normal'}>
 								{` $${formatAmount(tvl?.tvlDeprecated, 2)}`}
 							</span>
 						</div>
 					</div>
 				</div>
-				<div className={'flex items-center max-sm:justify-center md:justify-start'}>
-					<span className={'flex cursor-pointer border border-dashed border-neutral-500 bg-neutral-200 px-4 py-2 font-mono text-sm text-neutral-700 transition-colors hover:bg-neutral-0 md:hidden'}>
-						{'🏦 Deploy vault'}
-					</span>
-					<span className={'hidden cursor-pointer border border-dashed border-neutral-500 bg-neutral-200 px-4 py-2 font-mono text-sm text-neutral-700 transition-colors hover:bg-neutral-0 md:block'}>
-						{'🏦 Deploy your own vault'}
-					</span>
+				<div className={'flex items-center justify-center text-sm md:justify-start'}>
+					<div className={'cursor-pointer border border-dashed border-neutral-500 bg-neutral-200 px-4 py-2 transition-colors hover:bg-neutral-0'}>
+						<span className={'md:hidden'}>
+							{'🏦 Deploy vault'}
+						</span>
+						<span className={'hidden md:block'}>
+							{'🏦 Deploy your own vault'}
+						</span>
+					</div>
 				</div>
 			</section>
 
-			<div className={'grid max-w-5xl grid-cols-2 gap-2'}>
-				<div className={'col-span-2 mb-4 w-full md:col-span-1'}>
-					<h2 className={'mb-4 font-mono text-2xl font-semibold text-neutral-900'}>{'🚀 Experimental'}</h2>
+			<div className={'grid grid-cols-2 gap-2'}>
+				<div className={'col-span-2 mb-4 md:col-span-1'}>
+					<h2 className={'mb-4 text-2xl font-semibold text-neutral-900'}>{'🚀 Experimental'}</h2>
 					<ul>
 						{vaultsActiveExperimental?.map((vault): ReactElement => (
 							<li key={vault.VAULT_SLUG} className={'flex cursor-pointer flex-row items-baseline'}>
@@ -285,7 +287,7 @@ function	Index(): ReactElement {
 												))
 											}
 										</span>
-										<span className={'dashed-underline-gray ml-4 cursor-pointer font-mono text-base font-normal text-neutral-700'}>
+										<span className={'dashed-underline-gray ml-4 cursor-pointer text-base font-normal text-neutral-700'}>
 											{vault.TITLE}
 										</span>
 									</div>
@@ -296,8 +298,8 @@ function	Index(): ReactElement {
 					</ul>
 				</div>
 
-				<div className={'col-span-2 mb-4 w-full md:col-span-1'}>
-					<h2 className={'mb-4 font-mono text-2xl font-semibold text-neutral-900'}>{'🧠 Weird'}</h2>
+				<div className={'col-span-2 mb-4 md:col-span-1'}>
+					<h2 className={'mb-4 text-2xl font-semibold text-neutral-900'}>{'🧠 Weird'}</h2>
 					<ul>
 						{vaultsActiveWeird?.map((vault): ReactElement => (
 							<li key={vault.VAULT_SLUG} className={'flex cursor-pointer flex-row items-baseline'}>
@@ -310,7 +312,7 @@ function	Index(): ReactElement {
 												))
 											}
 										</span>
-										<span className={'dashed-underline-gray ml-4 cursor-pointer font-mono text-base font-normal text-neutral-700'}>
+										<span className={'dashed-underline-gray ml-4 cursor-pointer text-base font-normal text-neutral-700'}>
 											{vault.TITLE}
 										</span>
 									</div>
@@ -320,7 +322,7 @@ function	Index(): ReactElement {
 						))}
 					</ul>
 
-					<h2 className={'mb-4 mt-12 font-mono text-2xl font-semibold text-neutral-900'}>{'🦍 Community'}</h2>
+					<h2 className={'mb-4 mt-12 text-2xl font-semibold text-neutral-900'}>{'🦍 Community'}</h2>
 					<ul>
 						{(communityVaults || [])?.map((vault: TVault): ReactElement => (
 							<li key={vault.VAULT_ADDR} className={'cursor-pointer'}>
@@ -329,7 +331,7 @@ function	Index(): ReactElement {
 										<span className={'flex flex-row items-center'}>
 											{'🦍🦍'}
 										</span>
-										<span className={'dashed-underline-gray ml-4 cursor-pointer font-mono text-base font-normal text-neutral-700'}>
+										<span className={'dashed-underline-gray ml-4 cursor-pointer text-base font-normal text-neutral-700'}>
 											{vault.SYMBOL || ''}
 										</span>
 									</div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -218,7 +218,7 @@ function	Index(): ReactElement {
 				</div>
 			</div>
 			<div className={'my-4 max-w-5xl bg-yellow-900 p-4 text-justify text-sm font-normal text-[#485570]'}>
-				{'⚠️ '}<strong>{'WARNING'}</strong> {"this experiments are experimental. They are extremely risky and will probably be discarded when the test is over. There's a good chance that you can lose your funds. If you choose to proceed, do it with extreme caution."}
+				{'⚠️ '}<strong>{'WARNING'}</strong> {"These experiments are experimental. They are extremely risky and will probably be discarded when the test is over. There's a good chance that you can lose your funds. If you choose to proceed, do it with extreme caution."}
 			</div>
 			<DisabledVaults vaultsInactive={vaultsInactiveForUser} />
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -77,7 +77,7 @@ function	DisabledVaults({vaultsInactive}: {vaultsInactive: TVault[]}): ReactElem
 		return <Fragment />;
 	}
 	return (
-		<div className={'my-4 max-w-5xl bg-red-900 p-4 pb-2 text-justify text-sm font-normal text-[#485570]'}>
+		<div className={'my-4 max-w-5xl bg-red-900 p-4 pb-2 text-justify text-sm font-normal'}>
 			{'⚠️ '}<strong>{'WARNING'}</strong>{' 🚨 '}<strong>{'YOU ARE USING DEPRECATED VAULTS'}</strong> {'You have funds in deprecated vaults. Theses vaults are no longer generating any profit and are now an image from the past. Please remove your funds from these vaults.'}
 			<div className={'mt-4'}>
 				<ul className={'grid grid-cols-2 gap-2'}>


### PR DESCRIPTION
## Description

This PR focused on to improve the  appearance of sections by applying media queries and adjusting some general styles. These styles changes are just opinion and can changing based on feedback.

The most relevant modifications:

* Adjust media query to make the section looks better on small screens.
<p align="center" width="100%"> 
<img width="80%" alt="Screenshot 2023-08-22 at 5 03 17 PM" src="https://github.com/saltyfacu/ape-tax/assets/104786213/47f4a79e-8e7a-4fe7-8e8c-be255b9a7887">
</p>
 
* Change the text-color to improve the readability of the 'Disabled' tag.

<p align="center" width="100%"> 
<img width="33%" alt="Screenshot 2023-08-23 at 2 34 15 AM" src="https://github.com/saltyfacu/ape-tax/assets/104786213/e277db79-3d1d-48c8-aa6d-63b84ffafd38">
</p>

* Justify text in warning boxes.
* Standardize the size and text color in the buttons of the zap section. 

## Motivation and Context

The motivation to make these smaller adjustments is to give better user experience.

## How Has This Been Tested?

Manually. To see some of the changes presented it's necessary to make some manual adjustments in the code. The images above are not representative of the page's current appearance, but they are attached to facilitate the revision of changes.
