### PR TITLE
chore: Add the new inline type import syntax

### DIFF
--- a/components/AnimatedWait.tsx
+++ b/components/AnimatedWait.tsx
@@ -1,6 +1,4 @@
-import {useEffect, useState} from 'react';
-
-import type {ReactElement} from 'react';
+import {type ReactElement, useEffect, useState} from 'react';
 
 function	AnimatedWait(): ReactElement {
 	const frames = ['[-----]', '[=----]', '[-=---]', '[--=--]', '[---=-]', '[----=]'];

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,11 +1,10 @@
-import {Fragment, useEffect, useMemo, useState} from 'react';
+import {Fragment, type ReactElement, useEffect, useMemo, useState} from 'react';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
 import {useConnect} from 'wagmi';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import {toAddress, truncateHex} from '@yearn-finance/web-lib/utils/address';
 
-import type {ReactElement} from 'react';
 import type {Chain} from 'viem';
 
 function stringToColour(str: string): string {

--- a/components/ProgressChart.tsx
+++ b/components/ProgressChart.tsx
@@ -1,6 +1,4 @@
-import {Fragment} from 'react';
-
-import type {ReactElement} from 'react';
+import {Fragment, type ReactElement} from 'react';
 
 function ProgressChart({progress = 0, width = 0}): ReactElement {
 	const	partChar = [' ', '▏', '▎', '▍', '▌', '▋', '▊', '▉', '█'];

--- a/components/Suspense.tsx
+++ b/components/Suspense.tsx
@@ -1,4 +1,4 @@
-import	AnimatedWait			from	'components/AnimatedWait';
+import AnimatedWait from 'components/AnimatedWait';
 
 import type {ReactElement, ReactNode} from 'react';
 

--- a/components/VaultActions.tsx
+++ b/components/VaultActions.tsx
@@ -1,8 +1,8 @@
-import {Fragment, useCallback, useState} from 'react';
+import {type ChangeEvent, Fragment, type ReactElement,useCallback, useState} from 'react';
 import {ethers} from 'ethers';
 import YVAULT_V3_BASE_ABI from 'utils/ABI/yVaultV3Base.abi';
 import {apeInVault, apeOutVault, approveERC20, depositERC20, withdrawERC20} from 'utils/actions';
-import {maxUint256} from 'viem';
+import {type ContractFunctionConfig, maxUint256} from 'viem';
 import {useNetwork} from 'wagmi';
 import {erc20ABI, fetchBalance, multicall, readContract} from '@wagmi/core';
 import {Button} from '@yearn-finance/web-lib/components/Button';
@@ -16,9 +16,7 @@ import {handleInputChangeEventValue} from '@yearn-finance/web-lib/utils/handlers
 import {isZero} from '@yearn-finance/web-lib/utils/isZero';
 import {defaultTxStatus} from '@yearn-finance/web-lib/utils/web3/transaction';
 
-import type {ChangeEvent, ReactElement} from 'react';
 import type {TVault, TVaultData} from 'utils/types';
-import type {ContractFunctionConfig} from 'viem';
 import type {TNDict} from '@yearn-finance/web-lib/types';
 import type {TransactionReceipt} from '@ethersproject/providers';
 

--- a/components/VaultDetails.tsx
+++ b/components/VaultDetails.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, type ReactElement, useEffect, useState} from 'react';
+import {Fragment, type ReactElement, useCallback, useEffect, useState} from 'react';
 import ProgressChart from 'components/ProgressChart';
 import Suspense from 'components/Suspense';
 import APR_ORACLE_V3_ABI from 'utils/ABI/yAPROracleV3.abi';

--- a/components/VaultDetails.tsx
+++ b/components/VaultDetails.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useState} from 'react';
+import {Fragment, useCallback, type ReactElement, useEffect, useState} from 'react';
 import ProgressChart from 'components/ProgressChart';
 import Suspense from 'components/Suspense';
 import APR_ORACLE_V3_ABI from 'utils/ABI/yAPROracleV3.abi';
@@ -12,7 +12,6 @@ import {formatToNormalizedValue} from '@yearn-finance/web-lib/utils/format.bigNu
 import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';
 import {isZero} from '@yearn-finance/web-lib/utils/isZero';
 
-import type {ReactElement} from 'react';
 import type {Maybe, TSpecificAPIResult, TVault, TVaultData} from 'utils/types';
 import type {TNDict} from '@yearn-finance/web-lib/types';
 

--- a/components/VaultStrategies.tsx
+++ b/components/VaultStrategies.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useState} from 'react';
+import {Fragment, type ReactElement, useCallback, useEffect, useState} from 'react';
 import {harvestStrategy} from 'utils/actions';
 import {useNetwork} from 'wagmi';
 import {erc20ABI, multicall, readContract} from '@wagmi/core';
@@ -10,7 +10,6 @@ import {decodeAsBigInt} from '@yearn-finance/web-lib/utils/decoder';
 import {formatToNormalizedValue, toBigInt, toNormalizedBN} from '@yearn-finance/web-lib/utils/format.bigNumber';
 import {isZero} from '@yearn-finance/web-lib/utils/isZero';
 
-import type {ReactElement} from 'react';
 import type {TStrategyData, TVault, TVaultData} from 'utils/types';
 import type {ContractFunctionConfig} from 'viem';
 import type {TAddress, TDict} from '@yearn-finance/web-lib/types';

--- a/components/VaultWrapper.tsx
+++ b/components/VaultWrapper.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react';
+import {type ReactElement, useCallback, useEffect, useState} from 'react';
 import InfoMessage from 'components/InfoMessage';
 import VaultActions from 'components/VaultActions';
 import VaultDetails from 'components/VaultDetails';
@@ -16,7 +16,6 @@ import {decodeAsBigInt} from '@yearn-finance/web-lib/utils/decoder';
 import {formatToNormalizedValue, toNormalizedBN} from '@yearn-finance/web-lib/utils/format.bigNumber';
 import {isZero} from '@yearn-finance/web-lib/utils/isZero';
 
-import type {ReactElement} from 'react';
 import type {TCoinGeckoPrices} from 'schemas/coinGeckoSchemas';
 import type {TVault, TVaultData} from 'utils/types';
 import type {TNDict} from '@yearn-finance/web-lib/types';

--- a/contexts/useFactory.tsx
+++ b/contexts/useFactory.tsx
@@ -1,4 +1,4 @@
-import {createContext, useCallback, useContext, useEffect, useState} from 'react';
+import {createContext, type ReactElement, useCallback, useContext, useEffect, useState} from 'react';
 import BALANCER_FACTORY_ABI from 'utils/ABI/balancerFactory.abi';
 import {multicall, readContract} from '@wagmi/core';
 import {useChainID} from '@yearn-finance/web-lib/hooks/useChainID';
@@ -6,7 +6,6 @@ import VAULT_ABI from '@yearn-finance/web-lib/utils/abi/vault.abi';
 import {toAddress} from '@yearn-finance/web-lib/utils/address';
 import performBatchedUpdates from '@yearn-finance/web-lib/utils/performBatchedUpdates';
 
-import type {ReactElement} from 'react';
 import type {TVault} from 'utils/types';
 
 type TFactoryContext = {

--- a/hooks/useFetch.ts
+++ b/hooks/useFetch.ts
@@ -1,8 +1,7 @@
-import useSWR from 'swr';
+import useSWR, {type SWRResponse} from 'swr';
 // import * as Sentry from '@sentry/nextjs';
 import {baseFetcher} from '@yearn-finance/web-lib/utils/fetchers';
 
-import type {SWRResponse} from 'swr';
 import type {z} from 'zod';
 
 type TUseZodProps<T> = {

--- a/pages/[slug]/index.tsx
+++ b/pages/[slug]/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useState} from 'react';
+import {Fragment, type ReactElement, useEffect, useState} from 'react';
 import {NextSeo} from 'next-seo';
 import VaultWrapper from 'components/VaultWrapper';
 import {useFactory} from 'contexts/useFactory';
@@ -7,7 +7,6 @@ import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import {toAddress} from '@yearn-finance/web-lib/utils/address';
 
 import type {GetStaticPathsResult, GetStaticPropsResult} from 'next';
-import type {ReactElement} from 'react';
 import type {TCoinGeckoPrices} from 'schemas/coinGeckoSchemas';
 import type {TVault} from 'utils/types';
 import type {TDict} from '@yearn-finance/web-lib/types';

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,6 +1,5 @@
-import Document, {Head, Html, Main, NextScript} from 'next/document';
+import Document, {type DocumentContext, type DocumentInitialProps, Head, Html, Main, NextScript} from 'next/document';
 
-import type {DocumentContext, DocumentInitialProps} from 'next/document';
 import type {ReactElement} from 'react';
 
 class MyDocument extends Document {

--- a/pages/api/tvl.ts
+++ b/pages/api/tvl.ts
@@ -1,5 +1,5 @@
 import {ethers} from 'ethers';
-import {coinGeckoPricesSchema} from 'schemas/coinGeckoSchemas';
+import {coinGeckoPricesSchema,type TCoinGeckoPrices} from 'schemas/coinGeckoSchemas';
 import vaults from 'utils/vaults.json';
 import {getPublicClient} from '@wagmi/core';
 import VAULT_ABI from '@yearn-finance/web-lib/utils/abi/vault.abi';
@@ -9,7 +9,6 @@ import {decodeAsBigInt} from '@yearn-finance/web-lib/utils/decoder';
 import {fetch} from '../../utils/fetch';
 
 import type {NextApiRequest, NextApiResponse} from 'next';
-import type {TCoinGeckoPrices} from 'schemas/coinGeckoSchemas';
 import type {TTVL} from 'utils/types';
 import type {ContractFunctionConfig} from 'viem';
 import type {TNDict} from '@yearn-finance/web-lib/types';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useState} from 'react';
+import {Fragment, type ReactElement, useCallback, useEffect, useState} from 'react';
 import Link from 'next/link';
 import {useFactory} from 'contexts/useFactory';
 import GraphemeSplitter from 'grapheme-splitter';
@@ -14,7 +14,6 @@ import {baseFetcher} from '@yearn-finance/web-lib/utils/fetchers';
 import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';
 import {isZero} from '@yearn-finance/web-lib/utils/isZero';
 
-import type {ReactElement} from 'react';
 import type {TTVL, TVault} from 'utils/types';
 import type {ContractFunctionConfig} from 'viem';
 import type {TDict} from '@yearn-finance/web-lib/types';

--- a/utils/actions.ts
+++ b/utils/actions.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import {encodeFunctionData, hexToSignature, maxUint256} from 'viem';
+import {type ContractFunctionConfig, encodeFunctionData, hexToSignature, maxUint256} from 'viem';
 import {erc20ABI, multicall, readContract, signTypedData} from '@wagmi/core';
 import VAULT_ABI from '@yearn-finance/web-lib/utils/abi/vault.abi';
 import {toAddress} from '@yearn-finance/web-lib/utils/address';
@@ -7,17 +7,15 @@ import {decodeAsBigInt} from '@yearn-finance/web-lib/utils/decoder';
 import {toBigInt} from '@yearn-finance/web-lib/utils/format.bigNumber';
 import {isZero} from '@yearn-finance/web-lib/utils/isZero';
 
-import {assertAddress, handleTx, toWagmiProvider} from './toWagmiProvider';
+import {assertAddress, handleTx, toWagmiProvider,type TWriteTransaction} from './toWagmiProvider';
 import FACTORY_KEEPER_ABI from './ABI/factoryKeeper.abi';
 import STRATEGY_V3_BASE_ABI from './ABI/tokenizedStrategyV3.abi';
 import YROUTER_ABI from './ABI/yRouter.abi';
 import YVAULT_V3_BASE_ABI from './ABI/yVaultV3Base.abi';
 
-import type {ContractFunctionConfig} from 'viem';
 import type {Connector} from 'wagmi';
 import type {TAddress} from '@yearn-finance/web-lib/types';
 import type {TTxResponse} from '@yearn-finance/web-lib/utils/web3/transaction';
-import type {TWriteTransaction} from './toWagmiProvider';
 
 const PERMIT_TYPE = {
 	Permit: [

--- a/utils/fetch.ts
+++ b/utils/fetch.ts
@@ -1,8 +1,7 @@
-import axios from 'axios';
+import axios, {type AxiosRequestConfig} from 'axios';
 // import * as Sentry from '@sentry/nextjs';
 import {serialize} from '@wagmi/core';
 
-import type {AxiosRequestConfig} from 'axios';
 import type {z} from 'zod';
 
 type TFetchProps = {

--- a/utils/toWagmiProvider.ts
+++ b/utils/toWagmiProvider.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
-import {BaseError} from 'viem';
-import {prepareWriteContract, waitForTransaction, writeContract} from '@wagmi/core';
+import {type Abi, BaseError, type SimulateContractParameters} from 'viem';
+import {type GetWalletClientResult, prepareWriteContract, waitForTransaction, type WalletClient, writeContract} from '@wagmi/core';
 import {toast} from '@yearn-finance/web-lib/components/yToast';
 import {toAddress} from '@yearn-finance/web-lib/utils/address';
 import {ZERO_ADDRESS} from '@yearn-finance/web-lib/utils/constants';
@@ -9,11 +9,10 @@ import {isEth} from '@yearn-finance/web-lib/utils/isEth';
 import {isTAddress} from '@yearn-finance/web-lib/utils/isTAddress';
 import {defaultTxStatus} from '@yearn-finance/web-lib/utils/web3/transaction';
 
-import type {Abi, SimulateContractParameters} from 'viem';
 import type {Connector} from 'wagmi';
 import type {TAddress} from '@yearn-finance/web-lib/types';
 import type {TTxResponse} from '@yearn-finance/web-lib/utils/web3/transaction';
-import type {GetWalletClientResult, WalletClient} from '@wagmi/core';
+
 
 export type TWagmiProviderContract = {
 	walletClient: GetWalletClientResult,

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -1,8 +1,6 @@
 import {z} from 'zod';
 
-import {fetch} from './fetch';
-
-import type {TFetchReturn} from './fetch';
+import {fetch, type TFetchReturn} from './fetch';
 
 export const blockTimestampResponseSchema = z.object({
 	status: z.string(),


### PR DESCRIPTION
## Description

This PR has purpose to adopt the new inline type import syntax in  the repo.

This change can be applied  when a file has two different imports for a same lib and he intention is to combine imports into a single line.

In the above example:
    
      import {useEffect, useState} from 'react';
      import type {ReactElement} from 'react';

The second line, which only contains the import type {ReactElement} from 'react', can be joined with the principal react import and all other complements. As shown below:

      import {type ReactElement, useEffect, useState} from 'react'

## Motivation and Context

Currently, some files have separate import types of other imports of the same library.  Although the code may look cleaner visually, the team suggested combining these imports to maintain consistency with official documentation.

Applying these adjustments  will make it easier to identify and manage all imports in one line, which is one of the advantages.

## How Has This Been Tested?

I ran `yarn dev` and confirmed that everything appeared as expected

## Resources

*   https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names