### PR TITLE
feat: add yearn-v3-LST

### DIFF
--- a/utils/vaults.json
+++ b/utils/vaults.json
@@ -1103,5 +1103,17 @@
     "COINGECKO_SYMBOL": "usdc",
     "VAULT_STATUS": "new",
     "CHAIN_ID": 137
+  },
+  "yearn-v3-LST": {
+    "TITLE": "V3 Liquid Staking Token",
+    "LOGO": "🌊🌊",
+    "VAULT_ABI": "v3-strategy",
+    "VAULT_TYPE": "experimental",
+    "VAULT_ADDR": "0x9CeDB174BD547f9a0f99Dca63660710d59B75AD4",
+    "WANT_ADDR": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+    "WANT_SYMBOL": "WMATIC",
+    "COINGECKO_SYMBOL": "wmatic",
+    "VAULT_STATUS": "new",
+    "CHAIN_ID": 137
   }
 }


### PR DESCRIPTION
## Description
Add yearn-V3-LST (Liquid Staking Token) strategy to apetax UI:
https://polygonscan.com/address/0x9cedb174bd547f9a0f99dca63660710d59b75ad4

## Related Issue

https://github.com/yearn/yearn-strategies/issues/570

## Motivation and Context

Add this yearn V3 strategy to ape tax UI to make it accessible to users

## How Has This Been Tested?

Tests in issue run successfully.
Deposit tx works well in the following tx: https://polygonscan.com/tx/0xbcfe23b6ccbdad5067ddbde4f02d04489bd92cb068f6e42c7e3a5889f6c29943
The strategy is being harvested by yHaaS: https://polygonscan.com/tx/0xcd074cb6cf3eb215edf00e6faea75689314f480dfcd5c232667d5fd30a22885d

## Resources
https://polygon.lido.fi/
https://app.balancer.fi/#/polygon/pool/0xf0ad209e2e969eaaa8c882aac71f02d8a047d5c2000200000000000000000b49