### PR TITLE
feat: add sUSDC

### DIFF
--- a/utils/vaults.json
+++ b/utils/vaults.json
@@ -765,7 +765,7 @@
     "WANT_ADDR": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3",
     "WANT_SYMBOL": "MIM",
     "COINGECKO_SYMBOL": "magic-internet-money",
-    "VAULT_STATUS": "active",
+    "VAULT_STATUS": "withdraw",
     "CHAIN_ID": 1
   },
   "gemini-saga": {
@@ -861,7 +861,7 @@
     "WANT_ADDR": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
     "WANT_SYMBOL": "LINK",
     "COINGECKO_SYMBOL": "chainlink",
-    "VAULT_STATUS": "active",
+    "VAULT_STATUS": "withdraw",
     "CHAIN_ID": 1
   },
   "curved-owl": {
@@ -909,7 +909,7 @@
     "WANT_ADDR": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
     "WANT_SYMBOL": "FRAX",
     "COINGECKO_SYMBOL": "frax",
-    "VAULT_STATUS": "active",
+    "VAULT_STATUS": "withdraw",
     "CHAIN_ID": 1
   },
   "bird-feeder": {
@@ -933,7 +933,7 @@
     "WANT_ADDR": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     "WANT_SYMBOL": "USDC",
     "COINGECKO_SYMBOL": "usd-coin",
-    "VAULT_STATUS": "new",
+    "VAULT_STATUS": "withdraw",
     "CHAIN_ID": 1
   },
   "xtreme-sushi": {
@@ -969,7 +969,7 @@
     "WANT_ADDR": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
     "WANT_SYMBOL": "USDC",
     "COINGECKO_SYMBOL": "usd-coin",
-    "VAULT_STATUS": "new",
+    "VAULT_STATUS": "withdraw",
     "CHAIN_ID": 1
   },
   "carpe-daiem": {
@@ -981,7 +981,7 @@
     "WANT_ADDR": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
     "WANT_SYMBOL": "DAI",
     "COINGECKO_SYMBOL": "dai",
-    "VAULT_STATUS": "new",
+    "VAULT_STATUS": "withdraw",
     "CHAIN_ID": 1
   },
   "methamorphosis": {
@@ -993,7 +993,7 @@
     "WANT_ADDR": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     "WANT_SYMBOL": "WETH",
     "COINGECKO_SYMBOL": "weth",
-    "VAULT_STATUS": "new",
+    "VAULT_STATUS": "active",
     "CHAIN_ID": 1
   },
   "dai-ape": {
@@ -1247,5 +1247,17 @@
     "COINGECKO_SYMBOL": "usd-coin",
     "VAULT_STATUS": "new",
     "CHAIN_ID": 42161
+  },
+  "yearn-V3-sUSDC": {
+    "TITLE": "sUSDC - Circle Maker",
+    "LOGO": "ⓂⓄ",
+    "VAULT_ABI": "v3-strategy",
+    "VAULT_TYPE": "experimental",
+    "VAULT_ADDR": "0xfB7C06DDd70C74ac2F68D0F947Be3b4C503e3D6c",
+    "WANT_ADDR": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "WANT_SYMBOL": "USDC",
+    "COINGECKO_SYMBOL": "usd-coin",
+    "VAULT_STATUS": "new",
+    "CHAIN_ID": 1
   }
 }


### PR DESCRIPTION
## Description
- add sUSDC strategy to apetax Mainnet (https://github.com/yearn/yearn-strategies/issues/652)
- clean up older retired V2 strategies on Mainnet

## Related Issue

https://github.com/yearn/yearn-strategies/issues/652

## Motivation and Context
- test out the sUSDC strategy on apetax
- clean up older retired V2 strategies on Mainnet so it does not clutter the frontend too much

## How Has This Been Tested?
Tests in the issue: https://github.com/yearn/yearn-strategies/issues/652

## Ressources
https://github.com/mil0xeth/yearn-v3-USDC-PSM-sDAI